### PR TITLE
[FEAT] 주문 취소 

### DIFF
--- a/src/main/java/store/ckin/front/oauth/CustomOauth2UserRequestConverter.java
+++ b/src/main/java/store/ckin/front/oauth/CustomOauth2UserRequestConverter.java
@@ -26,7 +26,6 @@ public class CustomOauth2UserRequestConverter
 
     @Override
     public RequestEntity<?> convert(OAuth2UserRequest userRequest) {
-        log.info("Convert Start");
 
         ClientRegistration clientRegistration = userRequest.getClientRegistration();
 

--- a/src/main/java/store/ckin/front/payment/adpter/PaymentAdapter.java
+++ b/src/main/java/store/ckin/front/payment/adpter/PaymentAdapter.java
@@ -1,6 +1,5 @@
 package store.ckin.front.payment.adpter;
 
-import java.io.UnsupportedEncodingException;
 import store.ckin.front.payment.dto.request.PaymentCancelReasonDto;
 import store.ckin.front.payment.dto.request.PaymentConfirmRequestDto;
 import store.ckin.front.payment.dto.request.PaymentRequestDto;
@@ -21,10 +20,8 @@ public interface PaymentAdapter {
      *
      * @param requestDto 결제 확인 요청 객체
      * @return 결제 확인 응답 객체
-     * @throws UnsupportedEncodingException 인코딩 예외
      */
-    PaymentConfirmResponseDto requestConfirmPayment(PaymentConfirmRequestDto requestDto)
-            throws UnsupportedEncodingException;
+    PaymentConfirmResponseDto requestConfirmPayment(PaymentConfirmRequestDto requestDto);
 
 
     /**

--- a/src/main/java/store/ckin/front/payment/adpter/PaymentAdapter.java
+++ b/src/main/java/store/ckin/front/payment/adpter/PaymentAdapter.java
@@ -1,6 +1,7 @@
 package store.ckin.front.payment.adpter;
 
 import java.io.UnsupportedEncodingException;
+import store.ckin.front.payment.dto.request.PaymentCancelReasonDto;
 import store.ckin.front.payment.dto.request.PaymentConfirmRequestDto;
 import store.ckin.front.payment.dto.request.PaymentRequestDto;
 import store.ckin.front.payment.dto.response.PaymentConfirmResponseDto;
@@ -34,4 +35,11 @@ public interface PaymentAdapter {
      */
     PaymentSuccessResponseDto requestCreatePayment(PaymentRequestDto requestDto);
 
+    /**
+     * 결제 취소 요청 메서드입니다.
+     *
+     * @param paymentKey 결제 키
+     * @param requestDto 결제 취소 요청 사유가 담긴 DTO
+     */
+    void requestCancelPayment(String paymentKey, PaymentCancelReasonDto requestDto);
 }

--- a/src/main/java/store/ckin/front/payment/adpter/impl/PaymentAdapterImpl.java
+++ b/src/main/java/store/ckin/front/payment/adpter/impl/PaymentAdapterImpl.java
@@ -2,7 +2,6 @@ package store.ckin.front.payment.adpter.impl;
 
 import static store.ckin.front.util.AdapterHeaderUtil.getHttpHeaders;
 
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
@@ -57,11 +56,9 @@ public class PaymentAdapterImpl implements PaymentAdapter {
      *
      * @param requestDto 결제 확인 요청 객체
      * @return 결제 확인 응답 객체
-     * @throws UnsupportedEncodingException 인코딩 예외
      */
     @Override
-    public PaymentConfirmResponseDto requestConfirmPayment(PaymentConfirmRequestDto requestDto)
-            throws UnsupportedEncodingException {
+    public PaymentConfirmResponseDto requestConfirmPayment(PaymentConfirmRequestDto requestDto) {
 
         String widgetSecretKey = keyManager.keyStore(tossProperties.getSecretKey());
 
@@ -117,7 +114,6 @@ public class PaymentAdapterImpl implements PaymentAdapter {
     public void requestCancelPayment(String paymentKey, PaymentCancelReasonDto requestDto) {
 
         String secretKey = keyManager.keyStore(tossProperties.getSecretKey());
-        log.info("secretKey = {}", secretKey);
 
         Base64.Encoder encoder = Base64.getEncoder();
         byte[] encodedBytes = encoder.encode((secretKey + ":").getBytes(StandardCharsets.UTF_8));
@@ -128,14 +124,13 @@ public class PaymentAdapterImpl implements PaymentAdapter {
 
         HttpEntity<PaymentCancelReasonDto> requestEntity = new HttpEntity<>(requestDto, httpHeaders);
 
-        ResponseEntity<Void> exchange = restTemplate.exchange(
+        restTemplate.exchange(
                 TOSS_API_URL + "/" + paymentKey + "/cancel",
                 HttpMethod.POST,
                 requestEntity,
                 new ParameterizedTypeReference<>() {
                 });
 
-        log.info("response status = {}", exchange.getStatusCode());
     }
 
     private HttpHeaders getTossHttpHeaders() {

--- a/src/main/java/store/ckin/front/payment/adpter/impl/PaymentAdapterImpl.java
+++ b/src/main/java/store/ckin/front/payment/adpter/impl/PaymentAdapterImpl.java
@@ -5,18 +5,22 @@ import static store.ckin.front.util.AdapterHeaderUtil.getHttpHeaders;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 import store.ckin.front.config.properties.GatewayProperties;
 import store.ckin.front.config.properties.TossProperties;
 import store.ckin.front.payment.adpter.PaymentAdapter;
+import store.ckin.front.payment.dto.request.PaymentCancelReasonDto;
 import store.ckin.front.payment.dto.request.PaymentConfirmRequestDto;
 import store.ckin.front.payment.dto.request.PaymentRequestDto;
 import store.ckin.front.payment.dto.response.PaymentConfirmResponseDto;
@@ -30,6 +34,7 @@ import store.ckin.front.skm.util.KeyManager;
  * @version 2024. 03. 09.
  */
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PaymentAdapterImpl implements PaymentAdapter {
@@ -44,7 +49,7 @@ public class PaymentAdapterImpl implements PaymentAdapter {
 
     private final KeyManager keyManager;
 
-    private static final String TOSS_API_URL = "https://api.tosspayments.com/v1/payments/confirm";
+    private static final String TOSS_API_URL = "https://api.tosspayments.com/v1/payments";
 
 
     /**
@@ -65,13 +70,13 @@ public class PaymentAdapterImpl implements PaymentAdapter {
         byte[] encodedBytes = encoder.encode((widgetSecretKey + ":").getBytes(StandardCharsets.UTF_8));
         String authorizations = new String(encodedBytes);
 
-        HttpHeaders httpHeaders = getHttpHeaders();
+        HttpHeaders httpHeaders = getTossHttpHeaders();
         httpHeaders.setBasicAuth(authorizations);
 
         HttpEntity<PaymentConfirmRequestDto> requestEntity = new HttpEntity<>(requestDto, httpHeaders);
 
         ResponseEntity<PaymentConfirmResponseDto> exchange = restTemplate.exchange(
-                TOSS_API_URL,
+                TOSS_API_URL + "/confirm",
                 HttpMethod.POST,
                 requestEntity,
                 new ParameterizedTypeReference<>() {
@@ -102,4 +107,42 @@ public class PaymentAdapterImpl implements PaymentAdapter {
         return exchange.getBody();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param paymentKey 결제 키
+     * @param requestDto 결제 취소 요청 사유가 담긴 DTO
+     */
+    @Override
+    public void requestCancelPayment(String paymentKey, PaymentCancelReasonDto requestDto) {
+
+        String secretKey = keyManager.keyStore(tossProperties.getSecretKey());
+        log.info("secretKey = {}", secretKey);
+
+        Base64.Encoder encoder = Base64.getEncoder();
+        byte[] encodedBytes = encoder.encode((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+        String authorizations = new String(encodedBytes);
+
+        HttpHeaders httpHeaders = getTossHttpHeaders();
+        httpHeaders.setBasicAuth(authorizations);
+
+        HttpEntity<PaymentCancelReasonDto> requestEntity = new HttpEntity<>(requestDto, httpHeaders);
+
+        ResponseEntity<Void> exchange = restTemplate.exchange(
+                TOSS_API_URL + "/" + paymentKey + "/cancel",
+                HttpMethod.POST,
+                requestEntity,
+                new ParameterizedTypeReference<>() {
+                });
+
+        log.info("response status = {}", exchange.getStatusCode());
+    }
+
+    private HttpHeaders getTossHttpHeaders() {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_JSON);
+        httpHeaders.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+        return httpHeaders;
+    }
 }

--- a/src/main/java/store/ckin/front/payment/controller/PaymentRestController.java
+++ b/src/main/java/store/ckin/front/payment/controller/PaymentRestController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import store.ckin.front.payment.dto.request.PaymentCancelRequestDto;
 import store.ckin.front.payment.dto.request.PaymentConfirmRequestDto;
 import store.ckin.front.payment.dto.request.PaymentRequestDto;
 import store.ckin.front.payment.dto.response.PaymentConfirmResponseDto;
@@ -57,5 +58,18 @@ public class PaymentRestController {
     @PostMapping("/success")
     public ResponseEntity<PaymentSuccessResponseDto> successPayment(@RequestBody PaymentRequestDto requestDto) {
         return ResponseEntity.ok(paymentFacade.createPayment(requestDto));
+    }
+
+    /**
+     * 결제 취소 요청 메서드입니다.
+     *
+     * @param requestDto 결제 키와 사유가 담긴 DTO
+     * @return 결제 취소 성공 응답
+     */
+    @PostMapping("/cancel")
+    public ResponseEntity<Void> cancelPayment(@RequestBody PaymentCancelRequestDto requestDto) {
+
+        paymentFacade.cancelPayment(requestDto.getPaymentKey(), requestDto.getCancelReason());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/store/ckin/front/payment/controller/PaymentRestController.java
+++ b/src/main/java/store/ckin/front/payment/controller/PaymentRestController.java
@@ -34,11 +34,9 @@ public class PaymentRestController {
      *
      * @param requestDto 결제 요청 JSON
      * @return 결제 요청 결과
-     * @throws Exception 예외 처리
      */
     @PostMapping("/confirm")
-    public ResponseEntity<PaymentConfirmResponseDto> confirmPayment(@RequestBody PaymentConfirmRequestDto requestDto)
-            throws Exception {
+    public ResponseEntity<PaymentConfirmResponseDto> confirmPayment(@RequestBody PaymentConfirmRequestDto requestDto) {
 
         PaymentConfirmResponseDto confirmPayment = paymentFacade.isConfirmPayment(requestDto);
 

--- a/src/main/java/store/ckin/front/payment/dto/PaymentStatus.java
+++ b/src/main/java/store/ckin/front/payment/dto/PaymentStatus.java
@@ -1,0 +1,11 @@
+package store.ckin.front.payment.dto;
+
+/**
+ * 결제 상태 enum.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+public enum PaymentStatus {
+    DONE, CANCEL
+}

--- a/src/main/java/store/ckin/front/payment/dto/request/PaymentCancelReasonDto.java
+++ b/src/main/java/store/ckin/front/payment/dto/request/PaymentCancelReasonDto.java
@@ -1,0 +1,19 @@
+package store.ckin.front.payment.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 주문 취소 사유가 담긴 DTO.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+
+@Getter
+@AllArgsConstructor
+public class PaymentCancelReasonDto {
+
+    private String cancelReason;
+
+}

--- a/src/main/java/store/ckin/front/payment/dto/request/PaymentCancelRequestDto.java
+++ b/src/main/java/store/ckin/front/payment/dto/request/PaymentCancelRequestDto.java
@@ -1,0 +1,19 @@
+package store.ckin.front.payment.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 결제 취소 요청 DTO.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+@Getter
+@AllArgsConstructor
+public class PaymentCancelRequestDto {
+
+    private String paymentKey;
+
+    private String cancelReason;
+}

--- a/src/main/java/store/ckin/front/payment/dto/request/PaymentRequestDto.java
+++ b/src/main/java/store/ckin/front/payment/dto/request/PaymentRequestDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
+import store.ckin.front.payment.dto.PaymentStatus;
 
 /**
  * 결제 요청 DTO 클래스입니다.
@@ -21,7 +22,7 @@ public class PaymentRequestDto {
 
     private String saleNumber;
 
-    private String paymentStatus;
+    private PaymentStatus paymentStatus;
 
     private LocalDateTime requestedAt;
 

--- a/src/main/java/store/ckin/front/payment/dto/response/PaymentResponseDto.java
+++ b/src/main/java/store/ckin/front/payment/dto/response/PaymentResponseDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
+import store.ckin.front.payment.dto.PaymentStatus;
 
 /**
  * 결제 조회 응답 DTO.
@@ -23,7 +24,7 @@ public class PaymentResponseDto {
 
     private String paymentKey;
 
-    private String paymentStatus;
+    private PaymentStatus paymentStatus;
 
     private LocalDateTime requestedAt;
 

--- a/src/main/java/store/ckin/front/payment/facde/PaymentFacade.java
+++ b/src/main/java/store/ckin/front/payment/facde/PaymentFacade.java
@@ -3,6 +3,7 @@ package store.ckin.front.payment.facde;
 import java.io.UnsupportedEncodingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import store.ckin.front.payment.dto.request.PaymentCancelReasonDto;
 import store.ckin.front.payment.dto.request.PaymentConfirmRequestDto;
 import store.ckin.front.payment.dto.request.PaymentRequestDto;
 import store.ckin.front.payment.dto.response.PaymentConfirmResponseDto;
@@ -57,5 +58,15 @@ public class PaymentFacade {
      */
     public PaymentSuccessResponseDto createPayment(PaymentRequestDto requestDto) {
         return paymentService.createPayment(requestDto);
+    }
+
+    /**
+     * 결제 취소 메서드입니다.
+     *
+     * @param paymentKey 결제 키
+     */
+    public void cancelPayment(String paymentKey, String reason) {
+        PaymentCancelReasonDto reasonDto = new PaymentCancelReasonDto(reason);
+        paymentService.cancelPayment(paymentKey, reasonDto);
     }
 }

--- a/src/main/java/store/ckin/front/payment/facde/PaymentFacade.java
+++ b/src/main/java/store/ckin/front/payment/facde/PaymentFacade.java
@@ -1,6 +1,5 @@
 package store.ckin.front.payment.facde;
 
-import java.io.UnsupportedEncodingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import store.ckin.front.payment.dto.request.PaymentCancelReasonDto;
@@ -43,10 +42,8 @@ public class PaymentFacade {
      *
      * @param requestDto 결제 확인 요청 객체
      * @return 결제 확인 응답 객체
-     * @throws UnsupportedEncodingException 인코딩 예외
      */
-    public PaymentConfirmResponseDto isConfirmPayment(PaymentConfirmRequestDto requestDto)
-            throws UnsupportedEncodingException {
+    public PaymentConfirmResponseDto isConfirmPayment(PaymentConfirmRequestDto requestDto) {
         return paymentService.isConfirmPayment(requestDto);
     }
 
@@ -64,6 +61,7 @@ public class PaymentFacade {
      * 결제 취소 메서드입니다.
      *
      * @param paymentKey 결제 키
+     * @param reason     취소 사유
      */
     public void cancelPayment(String paymentKey, String reason) {
         PaymentCancelReasonDto reasonDto = new PaymentCancelReasonDto(reason);

--- a/src/main/java/store/ckin/front/payment/service/PaymentService.java
+++ b/src/main/java/store/ckin/front/payment/service/PaymentService.java
@@ -1,6 +1,7 @@
 package store.ckin.front.payment.service;
 
 import java.io.UnsupportedEncodingException;
+import store.ckin.front.payment.dto.request.PaymentCancelReasonDto;
 import store.ckin.front.payment.dto.request.PaymentConfirmRequestDto;
 import store.ckin.front.payment.dto.request.PaymentRequestDto;
 import store.ckin.front.payment.dto.response.PaymentConfirmResponseDto;
@@ -31,4 +32,11 @@ public interface PaymentService {
      */
     PaymentSuccessResponseDto createPayment(PaymentRequestDto requestDto);
 
+    /**
+     * 결제 취소 메서드입니다.
+     *
+     * @param paymentKey 결제 키
+     * @param reasonDto  결제 취소 요청 사유가 담긴 DTO
+     */
+    void cancelPayment(String paymentKey, PaymentCancelReasonDto reasonDto);
 }

--- a/src/main/java/store/ckin/front/payment/service/PaymentService.java
+++ b/src/main/java/store/ckin/front/payment/service/PaymentService.java
@@ -1,6 +1,5 @@
 package store.ckin.front.payment.service;
 
-import java.io.UnsupportedEncodingException;
 import store.ckin.front.payment.dto.request.PaymentCancelReasonDto;
 import store.ckin.front.payment.dto.request.PaymentConfirmRequestDto;
 import store.ckin.front.payment.dto.request.PaymentRequestDto;
@@ -20,9 +19,8 @@ public interface PaymentService {
      *
      * @param requestDto 결제 확인 요청 객체
      * @return 결제 확인 응답 객체
-     * @throws UnsupportedEncodingException 인코딩 예외
      */
-    PaymentConfirmResponseDto isConfirmPayment(PaymentConfirmRequestDto requestDto) throws UnsupportedEncodingException;
+    PaymentConfirmResponseDto isConfirmPayment(PaymentConfirmRequestDto requestDto);
 
     /**
      * 결제 생성 메서드입니다.

--- a/src/main/java/store/ckin/front/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/store/ckin/front/payment/service/impl/PaymentServiceImpl.java
@@ -4,6 +4,7 @@ import java.io.UnsupportedEncodingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import store.ckin.front.payment.adpter.PaymentAdapter;
+import store.ckin.front.payment.dto.request.PaymentCancelReasonDto;
 import store.ckin.front.payment.dto.request.PaymentConfirmRequestDto;
 import store.ckin.front.payment.dto.request.PaymentRequestDto;
 import store.ckin.front.payment.dto.response.PaymentConfirmResponseDto;
@@ -25,7 +26,7 @@ public class PaymentServiceImpl implements PaymentService {
 
 
     /**
-     * 결제 확인 메서드입니다.
+     * {@inheritDoc}
      *
      * @param requestDto 결제 확인 요청 객체
      * @return 결제 확인 응답 객체
@@ -38,12 +39,24 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     /**
-     * 결제 생성 메서드입니다.
+     * {@inheritDoc}
      *
      * @param requestDto 결제 요청 객체
      */
     @Override
     public PaymentSuccessResponseDto createPayment(PaymentRequestDto requestDto) {
         return paymentAdapter.requestCreatePayment(requestDto);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param paymentKey 결제 키
+     * @param requestDto 결제 취소 요청 사유가 담긴 DTO
+     */
+    @Override
+    public void cancelPayment(String paymentKey, PaymentCancelReasonDto requestDto) {
+
+        paymentAdapter.requestCancelPayment(paymentKey, requestDto);
     }
 }

--- a/src/main/java/store/ckin/front/payment/service/impl/PaymentServiceImpl.java
+++ b/src/main/java/store/ckin/front/payment/service/impl/PaymentServiceImpl.java
@@ -1,6 +1,5 @@
 package store.ckin.front.payment.service.impl;
 
-import java.io.UnsupportedEncodingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import store.ckin.front.payment.adpter.PaymentAdapter;
@@ -30,11 +29,9 @@ public class PaymentServiceImpl implements PaymentService {
      *
      * @param requestDto 결제 확인 요청 객체
      * @return 결제 확인 응답 객체
-     * @throws UnsupportedEncodingException 인코딩 예외
      */
     @Override
-    public PaymentConfirmResponseDto isConfirmPayment(PaymentConfirmRequestDto requestDto)
-            throws UnsupportedEncodingException {
+    public PaymentConfirmResponseDto isConfirmPayment(PaymentConfirmRequestDto requestDto) {
         return paymentAdapter.requestConfirmPayment(requestDto);
     }
 

--- a/src/main/java/store/ckin/front/sale/adapter/SaleAdapter.java
+++ b/src/main/java/store/ckin/front/sale/adapter/SaleAdapter.java
@@ -111,5 +111,5 @@ public interface SaleAdapter {
      *
      * @param saleId 주문 ID
      */
-    void requestCancelSale(String saleId);
+    void requestCancelSale(Long saleId);
 }

--- a/src/main/java/store/ckin/front/sale/adapter/SaleAdapter.java
+++ b/src/main/java/store/ckin/front/sale/adapter/SaleAdapter.java
@@ -4,6 +4,7 @@ import java.util.List;
 import store.ckin.front.common.dto.PagedResponse;
 import store.ckin.front.coupon.dto.response.GetCouponResponseDto;
 import store.ckin.front.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.front.sale.dto.request.SaleDeliveryUpdateRequestDto;
 import store.ckin.front.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.front.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.front.sale.dto.response.SaleResponseDto;
@@ -96,4 +97,19 @@ public interface SaleAdapter {
      * @return 주문 상세 정보 응답 DTO
      */
     SaleDetailResponseDto requestGetMemberSaleDetailBySaleNumber(String saleNumber, String memberId);
+
+    /**
+     * 주문 배송 상태를 업데이트합니다.
+     *
+     * @param saleId         주문 ID
+     * @param deliveryStatus 배송 상태
+     */
+    void requestUpdateDeliveryStatus(Long saleId, SaleDeliveryUpdateRequestDto deliveryStatus);
+
+    /**
+     * 주문 취소를 요청합니다.
+     *
+     * @param saleId 주문 ID
+     */
+    void requestCancelSale(String saleId);
 }

--- a/src/main/java/store/ckin/front/sale/adapter/impl/SaleAdapterImpl.java
+++ b/src/main/java/store/ckin/front/sale/adapter/impl/SaleAdapterImpl.java
@@ -16,6 +16,7 @@ import store.ckin.front.config.properties.GatewayProperties;
 import store.ckin.front.coupon.dto.response.GetCouponResponseDto;
 import store.ckin.front.sale.adapter.SaleAdapter;
 import store.ckin.front.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.front.sale.dto.request.SaleDeliveryUpdateRequestDto;
 import store.ckin.front.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.front.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.front.sale.dto.response.SaleResponseDto;
@@ -210,6 +211,13 @@ public class SaleAdapterImpl implements SaleAdapter {
         return exchange.getBody();
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param saleNumber 주문 번호
+     * @param memberId   회원 ID
+     * @return 주문 상세 정보 응답 DTO
+     */
     @Override
     public SaleDetailResponseDto requestGetMemberSaleDetailBySaleNumber(String saleNumber, String memberId) {
 
@@ -224,5 +232,42 @@ public class SaleAdapterImpl implements SaleAdapter {
                 }, saleNumber, memberId);
 
         return exchange.getBody();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param saleId         주문 ID
+     * @param deliveryStatus 배송 상태
+     */
+    @Override
+    public void requestUpdateDeliveryStatus(Long saleId, SaleDeliveryUpdateRequestDto deliveryStatus) {
+
+        HttpEntity<SaleDeliveryUpdateRequestDto> requestEntity = new HttpEntity<>(deliveryStatus, getHttpHeaders());
+
+        restTemplate.exchange(
+                gatewayProperties.getGatewayUri() + SALE_URL + "/{saleId}/delivery/status",
+                HttpMethod.PUT,
+                requestEntity,
+                new ParameterizedTypeReference<Void>() {
+                }, saleId);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param saleId 주문 ID
+     */
+    @Override
+    public void requestCancelSale(String saleId) {
+
+        HttpEntity<Void> requestEntity = new HttpEntity<>(getHttpHeaders());
+
+        restTemplate.exchange(
+                gatewayProperties.getGatewayUri() + SALE_URL + "/{saleId}/cancel",
+                HttpMethod.PUT,
+                requestEntity,
+                new ParameterizedTypeReference<Void>() {
+                }, saleId);
     }
 }

--- a/src/main/java/store/ckin/front/sale/adapter/impl/SaleAdapterImpl.java
+++ b/src/main/java/store/ckin/front/sale/adapter/impl/SaleAdapterImpl.java
@@ -259,7 +259,7 @@ public class SaleAdapterImpl implements SaleAdapter {
      * @param saleId 주문 ID
      */
     @Override
-    public void requestCancelSale(String saleId) {
+    public void requestCancelSale(Long saleId) {
 
         HttpEntity<Void> requestEntity = new HttpEntity<>(getHttpHeaders());
 

--- a/src/main/java/store/ckin/front/sale/controller/AdminSaleController.java
+++ b/src/main/java/store/ckin/front/sale/controller/AdminSaleController.java
@@ -9,8 +9,10 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import store.ckin.front.common.dto.PagedResponse;
+import store.ckin.front.sale.dto.request.SaleDeliveryUpdateRequestDto;
 import store.ckin.front.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.front.sale.dto.response.SaleResponseDto;
 import store.ckin.front.sale.facade.SaleFacade;
@@ -64,5 +66,21 @@ public class AdminSaleController {
 
         model.addAttribute("saleDetail", saleDetail);
         return "admin/sale/detail";
+    }
+
+    /**
+     * 주문 배송 상태를 업데이트하는 메서드입니다.
+     *
+     * @param saleId         주문 ID
+     * @param deliveryStatus 배송 상태
+     * @return 주문 상세 페이지
+     */
+    @PutMapping("/{saleId}/delivery")
+    public String updateDeliveryStatus(@PathVariable("saleId") Long saleId,
+                                       SaleDeliveryUpdateRequestDto deliveryStatus) {
+
+        log.info("saleId = {}, deliveryStatus = {}", saleId, deliveryStatus);
+        saleFacade.updateDeliveryStatus(saleId, deliveryStatus);
+        return "redirect:/admin/sale/" + saleId;
     }
 }

--- a/src/main/java/store/ckin/front/sale/controller/AdminSaleController.java
+++ b/src/main/java/store/ckin/front/sale/controller/AdminSaleController.java
@@ -79,7 +79,6 @@ public class AdminSaleController {
     public String updateDeliveryStatus(@PathVariable("saleId") Long saleId,
                                        SaleDeliveryUpdateRequestDto deliveryStatus) {
 
-        log.info("saleId = {}, deliveryStatus = {}", saleId, deliveryStatus);
         saleFacade.updateDeliveryStatus(saleId, deliveryStatus);
         return "redirect:/admin/sale/" + saleId;
     }

--- a/src/main/java/store/ckin/front/sale/controller/SaleController.java
+++ b/src/main/java/store/ckin/front/sale/controller/SaleController.java
@@ -4,14 +4,12 @@ import java.util.List;
 import javax.servlet.http.Cookie;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import store.ckin.front.aop.Member;
@@ -27,7 +25,6 @@ import store.ckin.front.sale.facade.SaleFacade;
  * @version 2024. 02. 25.
  */
 
-@Slf4j
 @Controller
 @RequestMapping("/sale")
 @RequiredArgsConstructor
@@ -71,8 +68,6 @@ public class SaleController {
     @PostMapping
     public String createSale(@CookieValue("CART_ID") Cookie cookie,
                              @Valid SaleCreateRequestDto requestDto) {
-
-        log.debug("requestDto = {}", requestDto);
 
         String saleNumber = saleFacade.createSale(requestDto);
         saleFacade.deleteCartItemAll(cookie.getValue());

--- a/src/main/java/store/ckin/front/sale/controller/SaleController.java
+++ b/src/main/java/store/ckin/front/sale/controller/SaleController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import store.ckin.front.aop.Member;
@@ -120,4 +121,6 @@ public class SaleController {
         model.addAttribute("saleDetail", saleDetail);
         return "sale/guest-order-detail";
     }
+
+
 }

--- a/src/main/java/store/ckin/front/sale/controller/SaleRestController.java
+++ b/src/main/java/store/ckin/front/sale/controller/SaleRestController.java
@@ -2,8 +2,11 @@ package store.ckin.front.sale.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import store.ckin.front.coupon.dto.response.GetCouponResponseDto;
@@ -16,6 +19,7 @@ import store.ckin.front.sale.service.SaleService;
  * @version 2024. 02. 27.
  */
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class SaleRestController {
@@ -36,5 +40,17 @@ public class SaleRestController {
 
         List<GetCouponResponseDto> getCouponResponseList = saleService.requestCouponsByMemberId(memberId, bookId);
         return ResponseEntity.ok(getCouponResponseList);
+    }
+
+    /**
+     * 주문 취소 요청 메서드입니다.
+     *
+     * @param saleId 주문 ID
+     * @return 주문 취소 성공 여부
+     */
+    @PutMapping("/sale/{saleId}/cancel")
+    public ResponseEntity<Void> cancelSale(@PathVariable String saleId) {
+        saleService.cancelSale(saleId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/store/ckin/front/sale/controller/SaleRestController.java
+++ b/src/main/java/store/ckin/front/sale/controller/SaleRestController.java
@@ -49,7 +49,7 @@ public class SaleRestController {
      * @return 주문 취소 성공 여부
      */
     @PutMapping("/sale/{saleId}/cancel")
-    public ResponseEntity<Void> cancelSale(@PathVariable String saleId) {
+    public ResponseEntity<Void> cancelSale(@PathVariable Long saleId) {
         saleService.cancelSale(saleId);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/store/ckin/front/sale/dto/DeliveryStatus.java
+++ b/src/main/java/store/ckin/front/sale/dto/DeliveryStatus.java
@@ -1,0 +1,13 @@
+package store.ckin.front.sale.dto;
+
+/**
+ * 주문의 배송 상태를 나타내는 Enum.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+public enum DeliveryStatus {
+    READY,
+    IN_PROGRESS,
+    DONE
+}

--- a/src/main/java/store/ckin/front/sale/dto/SalePaymentStatus.java
+++ b/src/main/java/store/ckin/front/sale/dto/SalePaymentStatus.java
@@ -1,0 +1,11 @@
+package store.ckin.front.sale.dto;
+
+/**
+ * 주문의 결제 상태를 나타내는 Enum.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+public enum SalePaymentStatus {
+    WAITING, PAID, CANCEL
+}

--- a/src/main/java/store/ckin/front/sale/dto/request/SaleCancelRequestDto.java
+++ b/src/main/java/store/ckin/front/sale/dto/request/SaleCancelRequestDto.java
@@ -1,0 +1,17 @@
+package store.ckin.front.sale.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 주문 취소 요청 DTO 입니다.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+@Getter
+@NoArgsConstructor
+public class SaleCancelRequestDto {
+
+    private String cancelReason;
+}

--- a/src/main/java/store/ckin/front/sale/dto/request/SaleDeliveryUpdateRequestDto.java
+++ b/src/main/java/store/ckin/front/sale/dto/request/SaleDeliveryUpdateRequestDto.java
@@ -1,0 +1,23 @@
+package store.ckin.front.sale.dto.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import store.ckin.front.sale.dto.DeliveryStatus;
+
+/**
+ * 배송 상태 변경 요청 DTO.
+ *
+ * @author 정승조
+ * @version 2024. 03. 19.
+ */
+
+@ToString
+@Getter
+@AllArgsConstructor
+public class SaleDeliveryUpdateRequestDto {
+
+    @NotNull(message = "유효한 배송 상태를 입력해주세요.")
+    private DeliveryStatus deliveryStatus;
+}

--- a/src/main/java/store/ckin/front/sale/dto/response/SaleResponseDto.java
+++ b/src/main/java/store/ckin/front/sale/dto/response/SaleResponseDto.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import store.ckin.front.sale.dto.DeliveryStatus;
+import store.ckin.front.sale.dto.SalePaymentStatus;
 
 /**
  * 주문 조회 응답 DTO.
@@ -17,23 +19,6 @@ import lombok.ToString;
 @Getter
 @NoArgsConstructor
 public class SaleResponseDto {
-
-    /**
-     * 주문의 배송 상태를 나타내는 Enum.
-     */
-    public enum DeliveryStatus {
-        READY,
-        IN_PROGRESS,
-        DONE
-    }
-
-    /**
-     * 주문의 결제 상태를 나타내는 Enum.
-     */
-    public enum PaymentStatus {
-        WAITING,
-        PAID
-    }
 
     private Long saleId;
 
@@ -67,6 +52,6 @@ public class SaleResponseDto {
 
     private Integer saleTotalPrice;
 
-    private PaymentStatus salePaymentStatus;
+    private SalePaymentStatus salePaymentStatus;
 
 }

--- a/src/main/java/store/ckin/front/sale/facade/SaleFacade.java
+++ b/src/main/java/store/ckin/front/sale/facade/SaleFacade.java
@@ -1,6 +1,7 @@
 package store.ckin.front.sale.facade;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ import store.ckin.front.coupon.service.CouponService;
 import store.ckin.front.deliverypolicy.service.DeliveryPolicyService;
 import store.ckin.front.packaging.service.PackagingService;
 import store.ckin.front.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.front.sale.dto.request.SaleDeliveryUpdateRequestDto;
 import store.ckin.front.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.front.sale.dto.response.SalePolicyResponseDto;
 import store.ckin.front.sale.dto.response.SaleResponseDto;
@@ -90,7 +92,7 @@ public class SaleFacade {
 
         List<Long> couponIds = requestDto.getBookSaleList().stream()
                 .map(BookSaleCreateRequestDto::getAppliedCouponId)
-                .filter(appliedCouponId -> appliedCouponId != 0)
+                .filter(appliedCouponId -> Objects.nonNull(appliedCouponId) && appliedCouponId != 0)
                 .collect(Collectors.toList());
 
         log.debug("couponIds = {}", couponIds);
@@ -161,5 +163,15 @@ public class SaleFacade {
      */
     public SaleDetailResponseDto getGuestSaleDetailBySaleNumber(String saleNumber, String ordererContact) {
         return saleService.getGuestSaleDetailBySaleNumber(saleNumber, ordererContact);
+    }
+
+    /**
+     * 주문 배송 상태를 업데이트하는 메서드입니다.
+     *
+     * @param saleId         주문 ID
+     * @param deliveryStatus 배송 상태
+     */
+    public void updateDeliveryStatus(Long saleId, SaleDeliveryUpdateRequestDto deliveryStatus) {
+        saleService.updateDeliveryStatus(saleId, deliveryStatus);
     }
 }

--- a/src/main/java/store/ckin/front/sale/service/SaleService.java
+++ b/src/main/java/store/ckin/front/sale/service/SaleService.java
@@ -113,6 +113,6 @@ public interface SaleService {
      *
      * @param saleId 주문 ID
      */
-    void cancelSale(String saleId);
+    void cancelSale(Long saleId);
 
 }

--- a/src/main/java/store/ckin/front/sale/service/SaleService.java
+++ b/src/main/java/store/ckin/front/sale/service/SaleService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import store.ckin.front.common.dto.PagedResponse;
 import store.ckin.front.coupon.dto.response.GetCouponResponseDto;
 import store.ckin.front.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.front.sale.dto.request.SaleDeliveryUpdateRequestDto;
 import store.ckin.front.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.front.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.front.sale.dto.response.SaleResponseDto;
@@ -97,4 +98,21 @@ public interface SaleService {
      * @return 주문 상세 정보 응답 DTO
      */
     SaleDetailResponseDto getMemberSaleDetailBySaleNumber(String saleNumber, String memberId);
+
+    /**
+     * 주문 배송 상태를 업데이트합니다.
+     *
+     * @param saleId         주문 ID
+     * @param deliveryStatus 배송 상태
+     */
+    void updateDeliveryStatus(Long saleId, SaleDeliveryUpdateRequestDto deliveryStatus);
+
+
+    /**
+     * 주문 취소를 요청합니다.
+     *
+     * @param saleId 주문 ID
+     */
+    void cancelSale(String saleId);
+
 }

--- a/src/main/java/store/ckin/front/sale/service/impl/SaleServiceImpl.java
+++ b/src/main/java/store/ckin/front/sale/service/impl/SaleServiceImpl.java
@@ -147,7 +147,7 @@ public class SaleServiceImpl implements SaleService {
      * @param saleId 주문 ID
      */
     @Override
-    public void cancelSale(String saleId) {
+    public void cancelSale(Long saleId) {
         saleAdapter.requestCancelSale(saleId);
     }
 

--- a/src/main/java/store/ckin/front/sale/service/impl/SaleServiceImpl.java
+++ b/src/main/java/store/ckin/front/sale/service/impl/SaleServiceImpl.java
@@ -7,6 +7,7 @@ import store.ckin.front.common.dto.PagedResponse;
 import store.ckin.front.coupon.dto.response.GetCouponResponseDto;
 import store.ckin.front.sale.adapter.SaleAdapter;
 import store.ckin.front.sale.dto.request.SaleCreateRequestDto;
+import store.ckin.front.sale.dto.request.SaleDeliveryUpdateRequestDto;
 import store.ckin.front.sale.dto.response.SaleDetailResponseDto;
 import store.ckin.front.sale.dto.response.SaleInfoResponseDto;
 import store.ckin.front.sale.dto.response.SaleResponseDto;
@@ -128,4 +129,26 @@ public class SaleServiceImpl implements SaleService {
     public SaleDetailResponseDto getMemberSaleDetailBySaleNumber(String saleNumber, String memberId) {
         return saleAdapter.requestGetMemberSaleDetailBySaleNumber(saleNumber, memberId);
     }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param saleId         주문 ID
+     * @param deliveryStatus 배송 상태
+     */
+    @Override
+    public void updateDeliveryStatus(Long saleId, SaleDeliveryUpdateRequestDto deliveryStatus) {
+        saleAdapter.requestUpdateDeliveryStatus(saleId, deliveryStatus);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param saleId 주문 ID
+     */
+    @Override
+    public void cancelSale(String saleId) {
+        saleAdapter.requestCancelSale(saleId);
+    }
+
 }

--- a/src/main/resources/static/css/mypageStyle.css
+++ b/src/main/resources/static/css/mypageStyle.css
@@ -1,5 +1,5 @@
 #layoutSidenav {
-    height: 100%;
+    /*height: 100%;*/
 }
 
 .circle {

--- a/src/main/resources/templates/admin/sale/detail.html
+++ b/src/main/resources/templates/admin/sale/detail.html
@@ -100,6 +100,15 @@
                 </div>
             </div>
 
+            <form style="margin-top: 15px" method="post" th:action="@{/admin/sale/{saleId}/delivery(saleId=${saleId}) }">
+                <input type="hidden" name="_method" value="put">
+                <input type="hidden" name="deliveryStatus" value="IN_PROGRESS">
+                <button class="m-t-50 btn btn-outline-secondary"
+                        type="submit">
+                    배송 중 상태로 변경
+                </button>
+            </form>
+
             <div style="margin-top: 30px">
                 <h4 class="m-t-15" style="color: dodgerblue" th:text="'결제 정보 : ' + *{salePaymentStatus}"> 결제 정보 </h4>
             </div>

--- a/src/main/resources/templates/member/mypage/order-detail.html
+++ b/src/main/resources/templates/member/mypage/order-detail.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"
+<html lang="ko"
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layouts/mypage-default}">
@@ -55,7 +55,7 @@
                     <div>
                         <div class="flex-w bor15 p-t-10 p-b-10 p-lr-40 p-lr-15-sm">
                             <span class="float-r w-100" style="color: darkgreen"
-                                th:text="'포인트 사용 금액 : ' + *{salePointUsage} "></span>
+                                  th:text="'포인트 사용 금액 : ' + *{salePointUsage} "></span>
                         </div>
                     </div>
 
@@ -100,11 +100,11 @@
                             </div>
 
                             <div class="stext-104 cl2 plh4 size-115 bor13 p-lr-20 m-r-10 m-tb-5 p-t-10">
-                                배송 상태 : <span th:text="*{saleDeliveryStatus}"></span>
+                                배송비 : <span th:text="*{saleDeliveryFee}"></span>
                             </div>
 
                             <div class="stext-104 cl2 plh4 size-115 bor13 p-lr-20 m-r-10 m-tb-5 p-t-10">
-                                배송비 : <span th:text="*{saleDeliveryFee}"></span>
+                                배송 상태 : <span th:text="*{saleDeliveryStatus}"></span>
                             </div>
                         </div>
                     </div>
@@ -129,16 +129,95 @@
                         결제 승인일 : <span th:text="*{#temporals.format(approvedAt, 'yyyy.MM.dd')}"></span>
                     </div>
 
-                    <button class="m-t-20 btn-outline-primary btn float-r" style="margin-top: 30px;"
+                    <button class="m-t-50 btn-outline-primary btn float-l"
                             th:onclick="|location.href='@{*{receiptUrl}}'|">
                         결제 영수증
                     </button>
                 </th:block>
+
+                <th:block
+                        th:if="${saleDetail.paymentResponseDto == null or saleDetail.paymentResponseDto.paymentStatus.name() != 'CANCEL'}">
+                    <button class="m-t-50 btn-outline-danger btn float-r"
+                            th:onclick="cancelOrder()">
+                        주문 취소
+                    </button>
+                </th:block>
+
+
             </div>
 
-            <!-- 상품 금액 + 포장 금액 + 배송비 -->
-
+            <h5 class="h5 m-tb-15 mx-auto" style="color: #bb2d3b">
+                ⚠ 주문 취소는 배송 상태가 준비 중(READY)인 경우에만 가능합니다.
+            </h5>
         </div>
+
+        <script th:inline="javascript">
+
+            /*<![CDATA[*/
+            const secretKey = [[${secretKey}]];
+            let payment = [[${saleDetail.paymentResponseDto}]];
+            const saleId = [[${saleDetail.saleResponseDto.saleId}]];
+            /*]]>*/
+            console.log(secretKey);
+            console.log(payment);
+
+            function cancelOrder() {
+                // 결제가 진행된 경우 결제 취소 요청
+                const cancelReason = prompt('주문 취소 사유를 입력해주세요.');
+
+                if (cancelReason == null) {
+                    return;
+                }
+
+                if (payment != null) {
+                    requestPaymentCancel(payment.paymentKey, cancelReason);
+                }
+
+                requestSaleCancel();
+            }
+
+            async function requestPaymentCancel(paymentKey, cancelReason) {
+
+                console.log("결제 취소 부름");
+
+                const requestData = {
+                    paymentKey: paymentKey,
+                    cancelReason: cancelReason
+                };
+
+                console.log(requestData);
+
+                const response = await fetch('/toss/cancel', {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(requestData),
+                });
+
+                if (!response.ok) {
+                    alert('주문 취소에 실패하였습니다.');
+                }
+            }
+
+            async function requestSaleCancel() {
+                try {
+                    const response = await fetch('/sale/' + saleId + '/cancel', {
+                        method: "PUT"
+                    });
+
+                    if (!response.ok) {
+                        alert('주문 취소에 실패하였습니다.');
+                    }
+
+                    // reload
+                    window.location.reload();
+                } catch (error) {
+                    alert(error.message);
+                }
+            }
+        </script>
+
     </div>
 </div>
 </html>

--- a/src/main/resources/templates/member/mypage/order-detail.html
+++ b/src/main/resources/templates/member/mypage/order-detail.html
@@ -17,6 +17,11 @@
         <div class="row m-t-150">
             <div class="col-lg-10 col-xl-7 m-lr-auto m-b-50">
 
+                <h4 th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() eq 'CANCEL'}"
+                    class="h4" style="color: #bb2d3b">
+                    취소된 주문입니다.
+                </h4>
+
                 <h4 class="m-t-30 m-b-30"
                     th:text="'결제 총 금액 : ' + ${saleDetail.saleResponseDto.saleTotalPrice} + '원'">
                 </h4>
@@ -154,12 +159,10 @@
         <script th:inline="javascript">
 
             /*<![CDATA[*/
-            const secretKey = [[${secretKey}]];
             let payment = [[${saleDetail.paymentResponseDto}]];
             const saleId = [[${saleDetail.saleResponseDto.saleId}]];
+
             /*]]>*/
-            console.log(secretKey);
-            console.log(payment);
 
             function cancelOrder() {
                 // 결제가 진행된 경우 결제 취소 요청
@@ -178,14 +181,11 @@
 
             async function requestPaymentCancel(paymentKey, cancelReason) {
 
-                console.log("결제 취소 부름");
 
                 const requestData = {
                     paymentKey: paymentKey,
                     cancelReason: cancelReason
                 };
-
-                console.log(requestData);
 
                 const response = await fetch('/toss/cancel', {
                     method: "POST",

--- a/src/main/resources/templates/member/mypage/order-detail.html
+++ b/src/main/resources/templates/member/mypage/order-detail.html
@@ -15,12 +15,11 @@
 
     <div class="container">
         <div class="row m-t-150">
+            <h4 th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() eq 'CANCEL'}"
+                class="h4 p-t-15" style="color: #bb2d3b">
+                취소된 주문입니다.
+            </h4>
             <div class="col-lg-10 col-xl-7 m-lr-auto m-b-50">
-
-                <h4 th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() eq 'CANCEL'}"
-                    class="h4" style="color: #bb2d3b">
-                    취소된 주문입니다.
-                </h4>
 
                 <h4 class="m-t-30 m-b-30"
                     th:text="'결제 총 금액 : ' + ${saleDetail.saleResponseDto.saleTotalPrice} + '원'">
@@ -151,9 +150,10 @@
 
             </div>
 
-            <h5 class="h5 m-tb-15 mx-auto" style="color: #bb2d3b">
-                ⚠ 주문 취소는 배송 상태가 준비 중(READY)인 경우에만 가능합니다.
-            </h5>
+            <p class="m-tb-15 mx-auto" style="color: #bb2d3b">
+                ⚠ 주문 취소는 배송 상태가 준비 중(READY)인 경우에만 가능합니다. <br/>
+                결제 후 주문이 취소되면, 환불 금액은 포인트로 적립됩니다.
+            </p>
         </div>
 
         <script th:inline="javascript">

--- a/src/main/resources/templates/sale/guest-order-detail.html
+++ b/src/main/resources/templates/sale/guest-order-detail.html
@@ -94,15 +94,17 @@
                             </div>
 
                             <div class="stext-104 cl2 plh4 size-115 bor13 p-lr-20 m-r-10 m-tb-5 p-t-10">
-                                배송 상태 : <span th:text="*{saleDeliveryStatus}"></span>
+                                배송비 : <span th:text="*{saleDeliveryFee}"></span>
                             </div>
 
                             <div class="stext-104 cl2 plh4 size-115 bor13 p-lr-20 m-r-10 m-tb-5 p-t-10">
-                                배송비 : <span th:text="*{saleDeliveryFee}"></span>
+                                배송 상태 : <span th:text="*{saleDeliveryStatus}"></span>
                             </div>
                         </div>
                     </div>
-
+                    <h5 class="h5 m-tb-15 mx-auto float-r" style="color: #bb2d3b">
+                        ⚠ 주문 취소는 배송 상태가 준비 중(READY)인 경우에만 가능합니다.
+                    </h5>
                 </div>
             </div>
             <div class="col-sm-10 col-lg-7 col-xl-5 m-lr-auto m-b-50">
@@ -124,13 +126,20 @@
                         결제 승인일 : <span th:text="*{#temporals.format(approvedAt, 'yyyy.MM.dd')}"></span>
                     </div>
 
-                    <button class="m-t-20 btn-outline-primary btn float-r" style="margin-top: 30px;"
+                    <button class="m-t-20 btn-outline-primary btn float-l" style="margin-top: 30px;"
                             th:onclick="|location.href='@{*{receiptUrl}}'|">
                         결제 영수증
                     </button>
                 </th:block>
 
+                <th:block th:if="${saleDetail.saleResponseDto.saleDeliveryStatus.name() eq 'READY'}">
+                    <button class="m-t-50 btn-outline-danger btn float-r"
+                            th:onclick="cancelOrder()">
+                        주문 취소
+                    </button>
+                </th:block>
             </div>
+
 
         </div>
     </div>

--- a/src/main/resources/templates/sale/guest-order-detail.html
+++ b/src/main/resources/templates/sale/guest-order-detail.html
@@ -16,15 +16,22 @@
 <div layout:fragment="content">
 
     <div class="container">
-        <div class="row m-t-150 w-100">
+        <div class="row m-t-150">
             <div class="col-lg-10 col-xl-7 m-lr-auto m-b-50">
 
-                <h3 class="h3 m-t-30 m-b-30"
-                    th:text="'결제 총 금액 : ' + ${saleDetail.saleResponseDto.saleTotalPrice} + '원'"></h3>
+                <h4 th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() eq 'CANCEL'}"
+                    class="h4" style="color: #bb2d3b">
+                    취소된 주문입니다.
+                </h4>
+
+                <h4 class="h4 m-t-30 m-b-30"
+                    th:text="'결제 총 금액 : ' + ${saleDetail.saleResponseDto.saleTotalPrice} + '원'">
+                </h4>
 
                 <div class="wrap-table-shopping-cart">
-                    <table class="table-shopping-cart"
-                           style="text-align: center; vertical-align: middle;margin-bottom: 0 !important;">
+
+                    <table class="table"
+                           style="text-align: center; vertical-align: middle; margin-bottom: 0 !important;">
                         <thead>
                         <tr>
                             <th scope="col" class="column-sj-1">상품 이미지</th>
@@ -52,6 +59,12 @@
                 </div>
 
                 <div th:object="${saleDetail.saleResponseDto}">
+                    <div>
+                        <div class="flex-w bor15 p-t-10 p-b-10 p-lr-40 p-lr-15-sm">
+                            <span class="float-r w-100" style="color: darkgreen"
+                                  th:text="'포인트 사용 금액 : ' + *{salePointUsage} "></span>
+                        </div>
+                    </div>
 
                     <div class="flex-w flex-sb-m bor15 p-t-18 p-b-15 p-lr-40 p-lr-15-sm">
 
@@ -102,15 +115,12 @@
                             </div>
                         </div>
                     </div>
-                    <h5 class="h5 m-tb-15 mx-auto float-r" style="color: #bb2d3b">
-                        ⚠ 주문 취소는 배송 상태가 준비 중(READY)인 경우에만 가능합니다.
-                    </h5>
                 </div>
             </div>
             <div class="col-sm-10 col-lg-7 col-xl-5 m-lr-auto m-b-50">
 
-                <h3 class="h3 m-t-30 m-b-30" style="color: #00235e"
-                    th:text="'결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus}"> 결제 정보 </h3>
+                <h4 class="h4 m-t-30 m-b-30" style="color: #00235e"
+                    th:text="'결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus}"> 결제 정보 </h4>
 
                 <th:block th:if="${saleDetail.paymentResponseDto != null}"
                           th:object="${saleDetail.paymentResponseDto}">
@@ -126,22 +136,89 @@
                         결제 승인일 : <span th:text="*{#temporals.format(approvedAt, 'yyyy.MM.dd')}"></span>
                     </div>
 
-                    <button class="m-t-20 btn-outline-primary btn float-l" style="margin-top: 30px;"
+                    <button class="m-t-50 btn-outline-primary btn float-l"
                             th:onclick="|location.href='@{*{receiptUrl}}'|">
                         결제 영수증
                     </button>
                 </th:block>
 
-                <th:block th:if="${saleDetail.saleResponseDto.saleDeliveryStatus.name() eq 'READY'}">
+                <th:block
+                        th:if="${saleDetail.paymentResponseDto == null or saleDetail.paymentResponseDto.paymentStatus.name() != 'CANCEL'}">
                     <button class="m-t-50 btn-outline-danger btn float-r"
                             th:onclick="cancelOrder()">
                         주문 취소
                     </button>
                 </th:block>
+
+
             </div>
 
-
+            <h5 class="h5 m-tb-15 mx-auto" style="color: #bb2d3b">
+                ⚠ 주문 취소는 배송 상태가 준비 중(READY)인 경우에만 가능합니다.
+            </h5>
         </div>
+
+        <script th:inline="javascript">
+
+            /*<![CDATA[*/
+            let payment = [[${saleDetail.paymentResponseDto}]];
+            const saleId = [[${saleDetail.saleResponseDto.saleId}]];
+
+            /*]]>*/
+
+            function cancelOrder() {
+                // 결제가 진행된 경우 결제 취소 요청
+                const cancelReason = prompt('주문 취소 사유를 입력해주세요.');
+
+                if (cancelReason == null) {
+                    return;
+                }
+
+                if (payment != null) {
+                    requestPaymentCancel(payment.paymentKey, cancelReason);
+                }
+
+                requestSaleCancel();
+            }
+
+            async function requestPaymentCancel(paymentKey, cancelReason) {
+
+                const requestData = {
+                    paymentKey: paymentKey,
+                    cancelReason: cancelReason
+                };
+
+                const response = await fetch('/toss/cancel', {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                    },
+                    body: JSON.stringify(requestData),
+                });
+
+                if (!response.ok) {
+                    alert('주문 취소에 실패하였습니다.');
+                }
+            }
+
+            async function requestSaleCancel() {
+                try {
+                    const response = await fetch('/sale/' + saleId + '/cancel', {
+                        method: "PUT"
+                    });
+
+                    if (!response.ok) {
+                        alert('주문 취소에 실패하였습니다.');
+                    }
+
+                    // reload
+                    window.location.reload();
+                } catch (error) {
+                    alert(error.message);
+                }
+            }
+        </script>
+
     </div>
 </div>
 </html>

--- a/src/main/resources/templates/sale/success.html
+++ b/src/main/resources/templates/sale/success.html
@@ -10,7 +10,7 @@
         <div class="row m-t-150 w-100">
             <div class="col-lg-10 col-xl-7 m-lr-auto m-b-50">
                 <div class="m-l-25 m-r--38 m-lr-0-xl m-t-50">
-                    <h2> 주문이 완료되었습니다 🥳 </h2>
+                    <h2 class="h2"> 주문이 완료되었습니다 🥳 </h2>
 
                     <br/>
                     <div class="m-t-15 m-b-15">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#180 

## 📝 작업 내용

- [x] 1. 토스 페이먼츠 서버 - 결제 취소 API 호출 (결제가 완료된 주문건만)
- [x] 2. API 서버 - 주문 취소 API 호출

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/93f6a67b-bb93-4c45-b9cb-1e8a52c6b7c9)

### API 서버
1. 주문의 상태를 CANCEL로 수정

#### 결제를 진행하지 않은 주문 (WAITING)

- 주문할 때 사용한 포인트를 돌려줍니다.
- 포인트 내역에 `주문 취소` 라고 내용을 기재합니다.


#### 결제를 진행한 주문 (PAID)

- **(주문 금액 + 주문할 때 사용한 포인트) - 결제를 하면서 쌓인 적립금**을 계산하여 회원에게 다시 돌려줍니다.
- 포인트 내역에 `주문 취소`라고 내용을 기재합니다.
- 주문이 완료된 결제 금액은 **포인트로 다시 반환**하는 방식으로 진행하였습니다. 

> 주문 금액 : 10,000원
> 주문할 때 사용한 포인트 : 1,770원
> 주문 적립금 : 1,000원 (10%)
> <img width="1470" alt="스크린샷 2024-03-19 오후 9 57 40" src="https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/08f8b712-1002-4b73-8afd-139d2087f894">


## 👀 참고 사항
> 토스 페이먼츠 API는 테스트용이기 때문에 취소를 확인하는 용도로만 사용하였습니다. 
> ![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/2fb4c864-de77-4030-91d7-03e70e4fd706)