### PR TITLE
[FEAT] 검색 기능 추가 및 페이지 디자인

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,12 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
         </dependency>
+
+        <!-- ElasticSearch -->
+        <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-elasticsearch</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/src/main/java/store/ckin/front/product/controller/ProductController.java
+++ b/src/main/java/store/ckin/front/product/controller/ProductController.java
@@ -84,12 +84,22 @@ public class ProductController {
         return "product/view";
     }
 
+    /**
+     * 해당 키워드로 연관된 상품들을 가져오는 메서드
+     *
+     * @param keyword 검색할 키워드
+     * @param page    페이징 처리할 페이지
+     * @param size    페이징 처리할 페이지 사이자
+     * @param model   View 로 넘겨주기 위한 모델
+     * @return 검색 페이지
+     * @author 김준현
+     */
     @GetMapping("/search")
     public String searchProduct(@RequestParam("keyword") @DefaultValue("") String keyword,
-                                @Positive @RequestParam(defaultValue = "0") int page,
+                                @Positive @RequestParam(defaultValue = "1") int page,
                                 @Positive @RequestParam(required = false, defaultValue = "10") int size, Model model) {
 
-        List<SearchProduct> searchResults = productService.findResultByKeyword(keyword, PageRequest.of(page, size));
+        List<SearchProduct> searchResults = productService.findResultByKeyword(keyword, PageRequest.of(page - 1, size));
 
         model.addAttribute("KEY_WORD", keyword);
         for (SearchProduct book : searchResults) {

--- a/src/main/java/store/ckin/front/product/controller/ProductController.java
+++ b/src/main/java/store/ckin/front/product/controller/ProductController.java
@@ -2,9 +2,11 @@ package store.ckin.front.product.controller;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import store.ckin.front.category.dto.response.CategoryResponseDto;
 import store.ckin.front.category.service.CategoryService;
 import store.ckin.front.coupontemplate.dto.response.PageDto;
+import store.ckin.front.product.domain.SearchProduct;
 import store.ckin.front.product.dto.response.BookListResponseDto;
 import store.ckin.front.product.dto.response.BookResponseDto;
 import store.ckin.front.product.service.ProductService;
@@ -82,9 +85,18 @@ public class ProductController {
     }
 
     @GetMapping("/search")
-    public String searchProduct(@RequestParam("keyword") @DefaultValue("") String keyword, Model model) {
-        log.debug(keyword);
+    public String searchProduct(@RequestParam("keyword") @DefaultValue("") String keyword,
+                                @Positive @RequestParam(defaultValue = "0") int page,
+                                @Positive @RequestParam(required = false, defaultValue = "10") int size, Model model) {
+
+        List<SearchProduct> searchResults = productService.findResultByKeyword(keyword, PageRequest.of(page, size));
+
         model.addAttribute("KEY_WORD", keyword);
+        for (SearchProduct book : searchResults) {
+            log.debug("book info: {}", book);
+        }
+        model.addAttribute("SEARCH_RESULT", searchResults);
+
         return "product/search";
     }
 }

--- a/src/main/java/store/ckin/front/product/domain/SearchProduct.java
+++ b/src/main/java/store/ckin/front/product/domain/SearchProduct.java
@@ -1,0 +1,40 @@
+package store.ckin.front.product.domain;
+
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+
+/**
+ * description:
+ *
+ * @author : dduneon
+ * @version : 2024. 03. 19
+ */
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Document(indexName = "books")
+public class SearchProduct {
+    @Id
+    @Field("book_id")
+    private Long id;
+    private String title;
+    private String description;
+    private String category;
+    private String publisher;
+    private String author;
+    private String thumbnail;
+    @Field("sale_price")
+    private Integer salePrice;
+    @Field("regular_price")
+    private Integer regularPrice;
+    @Field("discount_rate")
+    private Integer discountRate;
+}

--- a/src/main/java/store/ckin/front/product/domain/SearchProduct.java
+++ b/src/main/java/store/ckin/front/product/domain/SearchProduct.java
@@ -20,7 +20,7 @@ import org.springframework.data.elasticsearch.annotations.Field;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Document(indexName = "books")
+@Document(indexName = "books", createIndex = false)
 public class SearchProduct {
     @Id
     @Field("book_id")

--- a/src/main/java/store/ckin/front/product/domain/SearchProduct.java
+++ b/src/main/java/store/ckin/front/product/domain/SearchProduct.java
@@ -11,9 +11,9 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 
 /**
- * description:
+ * Elasticsearch 내부에 저장되어 있는 도큐먼트 형식
  *
- * @author : dduneon
+ * @author : 김준현
  * @version : 2024. 03. 19
  */
 @ToString

--- a/src/main/java/store/ckin/front/product/repository/ProductSearchRepository.java
+++ b/src/main/java/store/ckin/front/product/repository/ProductSearchRepository.java
@@ -1,0 +1,53 @@
+package store.ckin.front.product.repository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.elasticsearch.index.query.MultiMatchQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.stereotype.Repository;
+import store.ckin.front.product.domain.SearchProduct;
+
+/**
+ * description:
+ *
+ * @author : dduneon
+ * @version : 2024. 03. 19
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class ProductSearchRepository {
+    private final ElasticsearchOperations operations;
+
+    public List<SearchProduct> findProductByKeyword(String keyword, PageRequest pageRequest) {
+        MultiMatchQueryBuilder query =
+                QueryBuilders.multiMatchQuery(keyword).fields(Map.of(
+                                "title.ngram", 3.0f,
+                                "title.nori", 3.0f,
+                                "description.ngram", 1.5f,
+                                "description.nori", 1.5f,
+                                "publisher", 2.0f,
+                                "author", 2.0f
+                        )
+                );
+        NativeSearchQuery nativeSearchQuery = new NativeSearchQueryBuilder()
+                .withQuery(query)
+                .withPageable(pageRequest)
+                .build();
+
+        String resultQuery = nativeSearchQuery.getQuery().toString();
+        log.debug("query : {}", resultQuery);
+
+        return operations.search(nativeSearchQuery, SearchProduct.class).get()
+                .map(SearchHit::getContent)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/store/ckin/front/product/repository/ProductSearchRepository.java
+++ b/src/main/java/store/ckin/front/product/repository/ProductSearchRepository.java
@@ -16,9 +16,9 @@ import org.springframework.stereotype.Repository;
 import store.ckin.front.product.domain.SearchProduct;
 
 /**
- * description:
+ * Elasticsearch 검색을 위한 레포지토리 클래스
  *
- * @author : dduneon
+ * @author : 김준현
  * @version : 2024. 03. 19
  */
 @Slf4j

--- a/src/main/java/store/ckin/front/product/service/ProductService.java
+++ b/src/main/java/store/ckin/front/product/service/ProductService.java
@@ -1,8 +1,10 @@
 package store.ckin.front.product.service;
 
 import java.util.List;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import store.ckin.front.coupontemplate.dto.response.PageDto;
+import store.ckin.front.product.domain.SearchProduct;
 import store.ckin.front.product.dto.response.BookListResponseDto;
 import store.ckin.front.product.dto.response.BookMainPageResponseDto;
 import store.ckin.front.product.dto.response.BookResponseDto;
@@ -33,4 +35,6 @@ public interface ProductService {
     List<BookMainPageResponseDto> findRecentBooks(Integer limit);
 
     List<BookMainPageResponseDto> findRecentBooksByCategoryId(Long categoryId, Integer limit);
+
+    List<SearchProduct> findResultByKeyword(String keyword, PageRequest pageRequest);
 }

--- a/src/main/java/store/ckin/front/product/service/ProductService.java
+++ b/src/main/java/store/ckin/front/product/service/ProductService.java
@@ -36,5 +36,12 @@ public interface ProductService {
 
     List<BookMainPageResponseDto> findRecentBooksByCategoryId(Long categoryId, Integer limit);
 
+    /**
+     * 해당 키워드를 가진 연관 도서들을 가져오는 메서드
+     *
+     * @param keyword     검색할 키워드
+     * @param pageRequest 페이지 요청
+     * @return 연관된 도서 목록
+     */
     List<SearchProduct> findResultByKeyword(String keyword, PageRequest pageRequest);
 }

--- a/src/main/java/store/ckin/front/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/store/ckin/front/product/service/impl/ProductServiceImpl.java
@@ -54,6 +54,13 @@ public class ProductServiceImpl implements ProductService {
         return productAdapter.findRecentBooksByCategoryId(categoryId, limit);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * @param keyword     검색할 키워드
+     * @param pageRequest 페이지 요청
+     * @return
+     */
     public List<SearchProduct> findResultByKeyword(String keyword, PageRequest pageRequest) {
         return productSearchRepository.findProductByKeyword(keyword, pageRequest);
     }

--- a/src/main/java/store/ckin/front/product/service/impl/ProductServiceImpl.java
+++ b/src/main/java/store/ckin/front/product/service/impl/ProductServiceImpl.java
@@ -2,13 +2,16 @@ package store.ckin.front.product.service.impl;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import store.ckin.front.coupontemplate.dto.response.PageDto;
 import store.ckin.front.product.adapter.ProductAdapter;
+import store.ckin.front.product.domain.SearchProduct;
 import store.ckin.front.product.dto.response.BookListResponseDto;
 import store.ckin.front.product.dto.response.BookMainPageResponseDto;
 import store.ckin.front.product.dto.response.BookResponseDto;
+import store.ckin.front.product.repository.ProductSearchRepository;
 import store.ckin.front.product.service.ProductService;
 
 /**
@@ -23,6 +26,7 @@ import store.ckin.front.product.service.ProductService;
 public class ProductServiceImpl implements ProductService {
 
     private final ProductAdapter productAdapter;
+    private final ProductSearchRepository productSearchRepository;
 
     /**
      * {@inheritDoc}
@@ -47,7 +51,11 @@ public class ProductServiceImpl implements ProductService {
 
     @Override
     public List<BookMainPageResponseDto> findRecentBooksByCategoryId(Long categoryId, Integer limit) {
-        return productAdapter.findRecentBooksByCategoryId(categoryId,limit);
+        return productAdapter.findRecentBooksByCategoryId(categoryId, limit);
+    }
+
+    public List<SearchProduct> findResultByKeyword(String keyword, PageRequest pageRequest) {
+        return productSearchRepository.findProductByKeyword(keyword, pageRequest);
     }
 
 }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,5 +1,6 @@
 # Redis Configuration (index)
 ckin.redis.cart-database-index=10
 ckin.redis.auth-database-index=12
-
 spring.devtools.livereload.enabled=true
+# Spring Data Elasticsearch Logging
+logging.level.org.springframework.data.elasticsearch.client.WIRE=TRACE

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,33 +1,30 @@
 spring.mvc.hiddenmethod.filter.enabled=true
 server.port=8080
 port.gateway-uri=http://localhost:9010
-
 # KeyStore
 ckin.keymanager.app-key=CuKPvJQR7enquqrZ
 ckin.keymanager.password=Z*9eaw9Va&M8Be
 ckin.keymanager.url=https://api-keymanager.nhncloudservice.com
 ckin.keymanager.path=/keymanager/v1.0/appkey/{appkey}/secrets/{keyid}
-
 # Redis Configuration
 ckin.redis.hostname=15676198d2bc4ad58bbdf73269edec9f
 ckin.redis.password=65b7e288cd964c7aaaf5190505f72427
 ckin.redis.port=e7e282b12bb141d2abe4cfa553f2a729
-
 toss.secret-key=4c81b783703a4566b6ef506e682d4219
 toss.client-key=test_ck_jExPeJWYVQGaL90nkEjo849R5gvN
-
 # Payco OAuth2
 spring.security.oauth2.client.registration.payco.client-id=3RDfffaLUByfMXBSN0a_lGu
 spring.security.oauth2.client.registration.payco.client-secret=UvmLtAB3hmQ_AKMnfD3gxAPI
 spring.security.oauth2.client.registration.payco.redirect-uri=http://test.com:8080/login/oauth2/code/payco
 spring.security.oauth2.client.registration.payco.client-authentication-method=client_secret_post
 spring.security.oauth2.client.registration.payco.authorization-grant-type=authorization_code
-
-spring.security.oauth2.client.provider.payco.authorization-uri= https://id.payco.com/oauth2.0/authorize?serviceProviderCode=FRIENDS&userLocale=ko_KR
+spring.security.oauth2.client.provider.payco.authorization-uri=https://id.payco.com/oauth2.0/authorize?serviceProviderCode=FRIENDS&userLocale=ko_KR
 spring.security.oauth2.client.provider.payco.token-uri=https://id.payco.com/oauth2.0/token
 spring.security.oauth2.client.provider.payco.user-info-uri=https://apis-payco.krp.toastoven.net/payco/friends/find_member_v2.json
 spring.security.oauth2.client.provider.payco.user-name-attribute=data
-
 # file size option
 spring.servlet.multipart.max-file-size=500MB
 spring.servlet.multipart.max-request-size=500MB
+# Elasticsearch
+spring.data.elasticsearch.repositories.enabled=true
+spring.elasticsearch.uris=133.186.216.71:9200

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -3833,7 +3833,7 @@ input.num-product::-webkit-inner-spin-button {
 
 .search-content-wrap {
     width: 83.33333%;
-    min-height: 1200px;
+    /*min-height: 1200px;*/
 }
 
 .search-page-title {
@@ -3846,7 +3846,7 @@ input.num-product::-webkit-inner-spin-button {
     display: table;
     margin: 0 auto;
     width: 100%;
-    min-height: 1200px;
+    /*min-height: 1200px;*/
     table-layout: fixed;
 }
 
@@ -3868,7 +3868,7 @@ input.num-product::-webkit-inner-spin-button {
 .search-result-filter-grip {
     position: static;
     width: 98%;
-    min-height: 1200px;
+    /*min-height: 1200px;*/
     margin: 0 auto;
     border: solid 1px #d8d8d8;
     background-color: #ffffff;
@@ -3878,11 +3878,16 @@ input.num-product::-webkit-inner-spin-button {
     border-bottom: solid 1px #ebebeb;
 }
 
+.search-filter dt a {
+    font-size: medium;
+}
+
 .search-result-contents-grip {
     position: relative;
     margin-left: 40px;
+    margin-bottom: 100px;
     width: auto;
-    min-height: 1200px;
+    /*min-height: 1200px;*/
 }
 
 .search-result-contents {
@@ -3917,6 +3922,24 @@ input.num-product::-webkit-inner-spin-button {
     align-items: center;
     width: 80%;
 }
+
+.search-filter-items-wrap {
+    display: flex;
+    flex-direction: row;
+    justify-content: left;
+    align-items: center;
+    margin: 10px;
+}
+
+.search-filter-items-wrap input {
+    margin-right: 5px;
+}
+
+.search-filter-items-wrap label {
+    margin: 0;
+    !important;
+}
+
 .search-result-right {
     display: flex;
     flex-direction: column;

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -3898,7 +3898,7 @@ input.num-product::-webkit-inner-spin-button {
     border: solid 1px #d8d8d8;
     width: 98%;
     height: 200px;
-    margin: 10px 1%;
+    margin-bottom: 10px;
     !important;
 }
 
@@ -3909,7 +3909,6 @@ input.num-product::-webkit-inner-spin-button {
     flex-direction: row;
     width: 100%;
     height: 100%;
-    border: solid 1px #6c757d;
 }
 
 .search-result-left {
@@ -3927,8 +3926,9 @@ input.num-product::-webkit-inner-spin-button {
 }
 
 .search-result-img {
-    width: 130px;
-    height: 150px;
+    width: 140px;
+    height: 160px;
+    margin-left: 10px;
 }
 
 .search-result-info {
@@ -3939,7 +3939,36 @@ input.num-product::-webkit-inner-spin-button {
     justify-content: center;
     height: 180px;
     width: auto;
-    margin-left: 10px;
+    margin-left: 20px;
+}
+
+.search-result-info a {
+    font-size: large;
+    font-weight: bold;
+    margin-bottom: 10px;
+}
+
+.search-result-author-info {
+    margin-bottom: 2px;
+}
+
+.author-title {
+    color: #5c636a;
+    margin-right: 3px;
+}
+
+.search-result-publisher-info {
+    margin-bottom: 7px;
+}
+
+.result-discount-rate {
+    color: #0a53be;
+    font-weight: bold;
+}
+
+.result-discount-price {
+    font-size: medium;
+    font-weight: bold;
 }
 
 .search-result-quantity {
@@ -3948,6 +3977,7 @@ input.num-product::-webkit-inner-spin-button {
     align-items: center;
     justify-content: center;
     width: 130px;
+    margin-bottom: 5px;
 }
 
 .search-result-quantity-btn {
@@ -4017,7 +4047,6 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 .btn-hover.color-8 {
     background-image: linear-gradient(to right, #29323c, #485563, #2b5876, #4e4376);
-    box-shadow: 0 4px 15px 0 rgba(45, 54, 65, 0.75);
 }
 /*////////////////////////////////////////////////////////////////////// */
 

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -270,14 +270,27 @@ Input, textarea : 14px/1.6 '', Arial, sans-serif;
 
 /*------------------------------------------------------------------
 [ Menu ]*/
+.search-nav {
+    min-width: 1200px;
+    !important;
+}
+
 .search-container {
     height: 100%;
-    width: auto;
+    width: 1100px;
     position: relative;
     display: flex;
     justify-content: center;
     align-items: flex-end;
-    margin-bottom: 5px;
+    margin: 0 auto;
+    !important;
+}
+
+.margin-container-250 {
+    margin-bottom: 20px;
+    margin-left: auto;
+    margin-right: auto;
+    !important;
 }
 
 .search {
@@ -295,6 +308,7 @@ Input, textarea : 14px/1.6 '', Arial, sans-serif;
     align-items: center;
     width: 600px;
     height: 60px;
+    !important;
 }
 
 .search-image-container {
@@ -494,7 +508,7 @@ input::placeholder {
 .wrap-icon-header {
     flex: none;
     display: flex;
-    justify-content: flex-end;
+    justify-content: center;
     align-items: center;
     line-height: 1;
     width: 120px;

--- a/src/main/resources/templates/fragments/index-header.html
+++ b/src/main/resources/templates/fragments/index-header.html
@@ -22,7 +22,7 @@
     <div class="container-menu-desktop ">
 
         <div class="wrap-menu-desktop how-shadow1">
-            <nav class="limiter-menu-desktop container">
+            <nav class="limiter-menu-desktop container search-nav">
 
                 <!-- Logo desktop -->
                 <a href="/" class="logo flex-l ">
@@ -30,7 +30,7 @@
                 </a>
 
                 <!-- Menu desktop -->
-                <div class="search-container mx-auto">
+                <div class="search-container margin-container-250">
                     <div class="search">
                         <a href="/" class="search-image-container">
                             <img src="/images/logo.png" alt="IMG-LOGO" class="search-image">

--- a/src/main/resources/templates/product/search.html
+++ b/src/main/resources/templates/product/search.html
@@ -10,7 +10,7 @@
         <div class="search-page-wrap p-t-15">
             <div class="search-content-wrap">
                 <div class="search-page-title">
-                    <em th:text="|${KEY_WORD} 에 대한 검색 결과가 0건 있습니다|"></em>
+                    <em th:text="|${KEY_WORD} 에 대한 검색 결과가 ${SEARCH_RESULT.size()}건 있습니다|"></em>
                 </div>
                 <div class="search-result-wrap">
                     <div class="search-result-filter-wrap">
@@ -32,13 +32,28 @@
                     <div class="search-result-contents-wrap">
                         <div class="search-result-contents-grip">
                             <div class="search-result-contents">
-                                <div class="search-result" th:each="number : ${#numbers.sequence(1, 10)}">
+                                <div class="search-result" th:each="book : ${SEARCH_RESULT}">
                                     <div class="search-result-col">
                                         <div class="search-result-left">
-                                            <img src="/images/logo.png" class="search-result-img" alt="result-img">
+                                            <a th:href="@{/product/view/${book.id}}">
+                                                <img th:src="${book.thumbnail}" class="search-result-img"
+                                                     alt="result-img">
+                                            </a>
                                             <div class="search-result-info">
-                                                <a>책이르</a>
-                                                <em>책책</em>
+                                                <a th:href="@{/product/view/${book.id}}" th:text="${book.title}"></a>
+                                                <div class="search-result-author-info">
+                                                    <em class="author-title">저자</em>
+                                                    <em th:text="${book.author}"></em>
+                                                </div>
+                                                <em class="search-result-publisher-info"
+                                                    th:text="${book.publisher}"></em>
+                                                <div class="search-result-price-info">
+                                                    <em class="result-discount-rate"
+                                                        th:text="|${book.discountRate}%|"></em>
+                                                    <em class="result-discount-price"
+                                                        th:text="${#numbers.formatInteger(book.salePrice, 3, 'COMMA') + '원'}"></em>
+                                                    <s th:text="${#numbers.formatInteger(book.regularPrice, 3, 'COMMA') + '원'}"></s>
+                                                </div>
                                             </div>
                                         </div>
                                         <div class="search-result-right">
@@ -52,8 +67,10 @@
                                                         type="button">+
                                                 </button>
                                             </div>
-                                            <button class="btn-hover color-8">장바구니 추가</button>
-                                            <button class="btn-hover color-8">바로 결제하기</button>
+                                            <form>
+                                                <button class="btn-hover color-8">장바구니 추가</button>
+                                                <button class="btn-hover color-8">바로 결제하기</button>
+                                            </form>
                                         </div>
                                     </div>
                                 </div>

--- a/src/main/resources/templates/product/search.html
+++ b/src/main/resources/templates/product/search.html
@@ -17,16 +17,46 @@
                         <div class="search-result-filter-grip">
                             <dl class="on pos-relative search-filter">
                                 <dt>
-                                    <a>분야</a>
+                                    <a>검색 대상</a>
                                 </dt>
                                 <dd>
                                     <ul>
-                                        <li>국내도서 ( )</li>
-                                        <li>외국도서 ( )</li>
+                                        <li class="search-filter-items-wrap">
+                                            <input id="searchByTitle" type="checkbox" value="" checked>
+                                            <label for="searchByTitle">책 제목</label>
+                                        </li>
+                                        <li class="search-filter-items-wrap">
+                                            <input id="searchByAuthor" type="checkbox" value="" checked>
+                                            <label for="searchByAuthor">저자</label>
+                                        </li>
+                                        <li class="search-filter-items-wrap">
+                                            <input id="searchByPublisher" type="checkbox" value="" checked>
+                                            <label for="searchByPublisher">출판사</label>
+                                        </li>
+                                        <li class="search-filter-items-wrap">
+                                            <input id="searchByDescription" type="checkbox" value="" checked>
+                                            <label for="searchByDescription">책 설명</label>
+                                        </li>
                                     </ul>
                                 </dd>
                             </dl>
-
+                            <dl class="on pos-relative search-filter">
+                                <dt>
+                                    <a>분류</a>
+                                </dt>
+                                <dd>
+                                    <ul>
+                                        <li class="search-filter-items-wrap">
+                                            <input id="searchWithInternal" type="checkbox" value="" checked>
+                                            <label for="searchWithInternal">국내 도서</label>
+                                        </li>
+                                        <li class="search-filter-items-wrap">
+                                            <input id="searchWithOverseas" type="checkbox" value="" checked>
+                                            <label for="searchWithOverseas">해외 도서</label>
+                                        </li>
+                                    </ul>
+                                </dd>
+                            </dl>
                         </div>
                     </div>
                     <div class="search-result-contents-wrap">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#152 #153 

## 📝 작업 내용

### 인덱스 헤더(index-header) 디자인 변경 및 검색바 추가

<img width="1216" alt="image" src="https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84072084/77fe9060-7a88-47ef-bb54-793c8b6a636c">

- [x] 로고 변경
- [x] 검색 바 추가
- [x] 검색어 없을 시 js로 검색 버튼 누르지 못하도록 변경
- [x] 적절한 display 요소 선택하여 정렬
- [x] margin 등 요소 간격 변경

### 검색 페이지 및 url 추가

```
/product/search?keyword=&page=&size=
```

- [x] 검색 페이지 연결 및 추가("/product/search")
- [x] 페이징 처리 추가( default : page=1, size=10 )

### 검색 페이지 추가

<img width="1191" alt="image" src="https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84072084/c384b5e5-f95a-4af6-aac6-7fde5e60d4a3">

- [x] 타이틀 검색어 및 검색 결과 개수 보여주도록 추가
- [x] 사이드바 검색 필터링 (#186)
- [x] 도서 정보 컨테이너 직접 디자인