### PR TITLE
[FEAT] SweetAlert 적용 & QA 해결 (주문 완료 후 페이지를 나간 경우)

### DIFF
--- a/src/main/resources/static/js/sale/form-check.js
+++ b/src/main/resources/static/js/sale/form-check.js
@@ -41,7 +41,20 @@ document.getElementById('submit-btn').addEventListener('click', function (event)
         event.preventDefault(); // 폼 전송 취소
 
         // 누락된 필드에 대한 알림 메시지 생성
-        const missingFieldsMessage = '입력되지 않은 항목이 존재합니다. 아래의 항목을 입력해주세요 👀\n\n' + missingFields.join('\n');
-        alert(missingFieldsMessage);
+        const missingFieldsMessage = missingFields.join(', ');
+
+        Swal.fire({
+            icon: "error",
+            title: "입력되지 않은 항목이 존재합니다.",
+            text: missingFieldsMessage,
+        });
+    } else {
+        Swal.fire({
+            icon: "success",
+            title: "주문이 성공적으로 완료되었습니다.",
+            showConfirmButton: false,
+            timer: 3000
+        });
     }
 });
+

--- a/src/main/resources/templates/member/mypage/order-detail.html
+++ b/src/main/resources/templates/member/mypage/order-detail.html
@@ -117,7 +117,14 @@
             <div class="col-sm-10 col-lg-7 col-xl-5 m-lr-auto m-b-50">
 
                 <h3 class="m-t-30 m-b-30" style="color: #00235e"
-                    th:text="'결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus}"> 결제 정보 </h3>
+                    th:text="'주문 결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus}"> 결제 정보 </h3>
+
+                <th:block th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() eq 'WAITING'}">
+                    <button class="m-t-50 btn-outline-primary btn float-l"
+                            th:onclick="|location.href='@{/sale/success/{saleNumber}(saleNumber=${saleNumber})}'|">
+                        결제하기
+                    </button>
+                </th:block>
 
                 <th:block th:if="${saleDetail.paymentResponseDto != null}"
                           th:object="${saleDetail.paymentResponseDto}">
@@ -139,8 +146,7 @@
                     </button>
                 </th:block>
 
-                <th:block
-                        th:if="${saleDetail.paymentResponseDto == null or saleDetail.paymentResponseDto.paymentStatus.name() != 'CANCEL'}">
+                <th:block th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() != 'CANCEL'}">
                     <button class="m-t-50 btn-outline-danger btn float-r"
                             th:onclick="cancelOrder()">
                         주문 취소
@@ -156,6 +162,7 @@
             </p>
         </div>
 
+        <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
         <script th:inline="javascript">
 
             /*<![CDATA[*/
@@ -166,37 +173,59 @@
 
             function cancelOrder() {
                 // 결제가 진행된 경우 결제 취소 요청
-                const cancelReason = prompt('주문 취소 사유를 입력해주세요.');
+                Swal.fire({
+                    title: '주문 취소 사유를 입력해주세요.',
+                    input: 'text',
+                    inputPlaceholder: '취소 사유를 입력하세요...',
+                    showCancelButton: true,
+                    confirmButtonText: '주문 취소',
+                    cancelButtonText: '취소',
+                    showLoaderOnConfirm: true,
+                    preConfirm: (cancelReason) => {
+                        if (!cancelReason) {
+                            Swal.showValidationMessage('취소 사유를 입력하세요.');
+                        } else {
+                            return {cancelReason: cancelReason};
+                        }
+                    },
+                    allowOutsideClick: () => !Swal.isLoading()
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        const cancelReason = result.value.cancelReason;
 
-                if (cancelReason == null) {
-                    return;
-                }
+                        if (payment != null) {
+                            requestPaymentCancel(payment.paymentKey, cancelReason);
+                        }
 
-                if (payment != null) {
-                    requestPaymentCancel(payment.paymentKey, cancelReason);
-                }
-
-                requestSaleCancel();
+                        requestSaleCancel();
+                    }
+                });
             }
 
             async function requestPaymentCancel(paymentKey, cancelReason) {
-
-
                 const requestData = {
                     paymentKey: paymentKey,
                     cancelReason: cancelReason
                 };
 
-                const response = await fetch('/toss/cancel', {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify(requestData),
-                });
+                try {
+                    const response = await fetch('/toss/cancel', {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify(requestData),
+                    });
 
-                if (!response.ok) {
-                    alert('주문 취소에 실패하였습니다.');
+                    if (!response.ok) {
+                        Swal.fire({
+                            icon: "error",
+                            title: "주문 취소에 실패하였습니다.",
+                            text: "다시 시도해주세요,",
+                        });
+                    }
+                } catch (error) {
+                    Swal.fire('에러', error.message, 'error');
                 }
             }
 
@@ -207,15 +236,20 @@
                     });
 
                     if (!response.ok) {
-                        alert('주문 취소에 실패하였습니다.');
+                        Swal.fire({
+                            icon: "error",
+                            title: "주문 취소에 실패하였습니다.",
+                            text: "다시 시도해주세요,",
+                        });
                     }
 
                     // reload
                     window.location.reload();
                 } catch (error) {
-                    alert(error.message);
+                    Swal.fire('에러', error.message, 'error');
                 }
             }
+
         </script>
 
     </div>

--- a/src/main/resources/templates/member/mypage/order-detail.html
+++ b/src/main/resources/templates/member/mypage/order-detail.html
@@ -174,9 +174,9 @@
             function cancelOrder() {
                 // 결제가 진행된 경우 결제 취소 요청
                 Swal.fire({
-                    title: '주문 취소 사유를 입력해주세요.',
+                    title: '주문 취소',
                     input: 'text',
-                    inputPlaceholder: '취소 사유를 입력하세요...',
+                    inputPlaceholder: '취소 사유를 입력해주세요..',
                     showCancelButton: true,
                     confirmButtonText: '주문 취소',
                     cancelButtonText: '취소',
@@ -244,7 +244,16 @@
                     }
 
                     // reload
-                    window.location.reload();
+                    Swal.fire({
+                        title: "주문이 취소되었습니다.",
+                        text: "환불 금액은 포인트로 적립됩니다.",
+                        icon: "success"
+
+                    }).then(() => {
+                        location.reload();
+                    });
+
+
                 } catch (error) {
                     Swal.fire('에러', error.message, 'error');
                 }

--- a/src/main/resources/templates/sale/guest-order-detail.html
+++ b/src/main/resources/templates/sale/guest-order-detail.html
@@ -179,9 +179,9 @@
             function cancelOrder() {
                 // 결제가 진행된 경우 결제 취소 요청
                 Swal.fire({
-                    title: '주문 취소 사유를 입력해주세요.',
+                    title: '주문 취소',
                     input: 'text',
-                    inputPlaceholder: '취소 사유를 입력하세요...',
+                    inputPlaceholder: '취소 사유를 입력해주세요..',
                     showCancelButton: true,
                     confirmButtonText: '주문 취소',
                     cancelButtonText: '취소',
@@ -249,14 +249,20 @@
                     }
 
                     // reload
-                    window.location.reload();
+                    Swal.fire({
+                        title: "주문이 취소되었습니다.",
+                        icon: "success"
+                    }).then(() => {
+                        location.reload();
+                    });
+
+
                 } catch (error) {
                     Swal.fire('에러', error.message, 'error');
                 }
             }
 
         </script>
-
 
     </div>
 </div>

--- a/src/main/resources/templates/sale/guest-order-detail.html
+++ b/src/main/resources/templates/sale/guest-order-detail.html
@@ -120,7 +120,14 @@
             <div class="col-sm-10 col-lg-7 col-xl-5 m-lr-auto m-b-50">
 
                 <h4 class="h4 m-t-30 m-b-30" style="color: #00235e"
-                    th:text="'결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus}"> 결제 정보 </h4>
+                    th:text="'주문 결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus}"> 결제 정보 </h4>
+
+                <th:block th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() eq 'WAITING'}">
+                    <button class="m-t-50 btn-outline-primary btn float-l"
+                            th:onclick="|location.href='@{/sale/success/{saleNumber}(saleNumber=${saleNumber})}'|">
+                        결제하기
+                    </button>
+                </th:block>
 
                 <th:block th:if="${saleDetail.paymentResponseDto != null}"
                           th:object="${saleDetail.paymentResponseDto}">
@@ -142,8 +149,10 @@
                     </button>
                 </th:block>
 
-                <th:block
-                        th:if="${saleDetail.paymentResponseDto == null or saleDetail.paymentResponseDto.paymentStatus.name() != 'CANCEL'}">
+                <span th:text="${saleDetail.saleResponseDto.salePaymentStatus.name()}">
+                </span>
+
+                <th:block th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() != 'CANCEL'}">
                     <button class="m-t-50 btn-outline-danger btn float-r"
                             th:onclick="cancelOrder()">
                         주문 취소
@@ -158,6 +167,7 @@
             </h5>
         </div>
 
+        <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
         <script th:inline="javascript">
 
             /*<![CDATA[*/
@@ -168,36 +178,59 @@
 
             function cancelOrder() {
                 // 결제가 진행된 경우 결제 취소 요청
-                const cancelReason = prompt('주문 취소 사유를 입력해주세요.');
+                Swal.fire({
+                    title: '주문 취소 사유를 입력해주세요.',
+                    input: 'text',
+                    inputPlaceholder: '취소 사유를 입력하세요...',
+                    showCancelButton: true,
+                    confirmButtonText: '주문 취소',
+                    cancelButtonText: '취소',
+                    showLoaderOnConfirm: true,
+                    preConfirm: (cancelReason) => {
+                        if (!cancelReason) {
+                            Swal.showValidationMessage('취소 사유를 입력하세요.');
+                        } else {
+                            return {cancelReason: cancelReason};
+                        }
+                    },
+                    allowOutsideClick: () => !Swal.isLoading()
+                }).then((result) => {
+                    if (result.isConfirmed) {
+                        const cancelReason = result.value.cancelReason;
 
-                if (cancelReason == null) {
-                    return;
-                }
+                        if (payment != null) {
+                            requestPaymentCancel(payment.paymentKey, cancelReason);
+                        }
 
-                if (payment != null) {
-                    requestPaymentCancel(payment.paymentKey, cancelReason);
-                }
-
-                requestSaleCancel();
+                        requestSaleCancel();
+                    }
+                });
             }
 
             async function requestPaymentCancel(paymentKey, cancelReason) {
-
                 const requestData = {
                     paymentKey: paymentKey,
                     cancelReason: cancelReason
                 };
 
-                const response = await fetch('/toss/cancel', {
-                    method: "POST",
-                    headers: {
-                        "Content-Type": "application/json",
-                    },
-                    body: JSON.stringify(requestData),
-                });
+                try {
+                    const response = await fetch('/toss/cancel', {
+                        method: "POST",
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                        body: JSON.stringify(requestData),
+                    });
 
-                if (!response.ok) {
-                    alert('주문 취소에 실패하였습니다.');
+                    if (!response.ok) {
+                        Swal.fire({
+                            icon: "error",
+                            title: "주문 취소에 실패하였습니다.",
+                            text: "다시 시도해주세요,",
+                        });
+                    }
+                } catch (error) {
+                    Swal.fire('에러', error.message, 'error');
                 }
             }
 
@@ -208,16 +241,22 @@
                     });
 
                     if (!response.ok) {
-                        alert('주문 취소에 실패하였습니다.');
+                        Swal.fire({
+                            icon: "error",
+                            title: "주문 취소에 실패하였습니다.",
+                            text: "다시 시도해주세요,",
+                        });
                     }
 
                     // reload
                     window.location.reload();
                 } catch (error) {
-                    alert(error.message);
+                    Swal.fire('에러', error.message, 'error');
                 }
             }
+
         </script>
+
 
     </div>
 </div>

--- a/src/main/resources/templates/sale/main.html
+++ b/src/main/resources/templates/sale/main.html
@@ -498,6 +498,7 @@
         <script src="/js/sale/coupon.js"></script>
     </th:block>
 
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <script src="/js/sale/form-check.js"></script>
 </div>
 </html>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[QA - 주문 완료](https://github.com/nhnacademy-be4-ckin/ckin-management/issues/41#issue-2197419061)

## 📝 작업 내용

### 기존에 사용하던 alert, prompt에 SweetAlert2를 적용하였습니다.

#### 주문 버튼 적용

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/aa7aa4fc-b7c6-4e70-bb82-2fb171769211)

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/04e0e303-19fe-4a4c-8822-01b45583230b)

#### 주문 취소 버튼 적용
![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/642553d4-bc20-490b-a895-d17300e83530)

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/f9182331-c902-4462-a2d3-142af4ee4dfa)

###  QA - 주문 완료
주문 완료 창을 나간 경우, 다시 결제 페이지로 이동할 수가 없었습니다.
이러한 문제를 해결하기 위해 주문 상세 페이지에서 결제 페이지로 이동할 수 있는 버튼을 생성하였습니다.

![스크린샷 2024-03-21 오전 11 36 36](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/9b985d00-ad3b-4c93-8041-16d540dd878b)


