### PR TITLE
[FEAT] 총 주문금액 동적 스크립트 작성 및 디자인

### DIFF
--- a/src/main/resources/static/js/cart.js
+++ b/src/main/resources/static/js/cart.js
@@ -1,3 +1,31 @@
+var totalPrice = 0;
+document.addEventListener(`DOMContentLoaded`, function () {
+    const checkboxes = document.querySelectorAll('.form-check-input');
+    checkboxes.forEach((checkbox, index) => {
+        if (index !== 0) {
+            checkbox.addEventListener('change', function (event) {
+                const element = event.target.parentNode;
+                const selectedPriceElement = element.querySelector('#order_total_price');
+
+                const selectedPrice = parseInt(selectedPriceElement.value);
+                console.log("selected: " + selectedPrice);
+                const totalPriceElement = document.querySelector('.shopping-cart-result');
+                console.log("total Price : " + totalPrice)
+                if (event.target.checked) {
+                    totalPrice += selectedPrice;
+                    totalPriceElement.innerText = (totalPrice).toLocaleString();
+                } else {
+                    totalPrice -= selectedPrice;
+                    totalPriceElement.innerText = (totalPrice).toLocaleString();
+                }
+            })
+        }
+    })
+    const selectAllCheckBox = document.querySelector('.form-check-input[id=checkAll]');
+    selectAllCheckBox.checked = true;
+    checkAll(selectAllCheckBox);
+})
+
 function clickUpdateBtn(btn) {
     const form = btn.parentNode;
     const currentQuantity = form.querySelector('input[name=quantity]').value;
@@ -13,7 +41,7 @@ function clickUpdateBtn(btn) {
         inputValue: currentQuantity
     }).then(
         (result) => {
-            if(result.isConfirmed) {
+            if (result.isConfirmed) {
                 const inputValue = Swal.getInput().value;
                 form.querySelector('input[name=quantity]').value = inputValue;
                 Swal.fire({
@@ -99,7 +127,19 @@ function clickDeleteBtn(btn) {
 function checkAll(checkBox) {
     console.log(checkBox.checked);
     const checkboxes = document.querySelectorAll('.form-check-input');
-    checkboxes.forEach((checkbox) => {
-        checkbox.checked = checkBox.checked;
+    totalPrice = 0;
+    checkboxes.forEach((element, index) => {
+        if (index !== 0) {
+            element.checked = checkBox.checked;
+            const totalPriceElement = element.parentNode.querySelector('#order_total_price');
+            console.log(totalPriceElement.value);
+            totalPrice += parseInt(element.parentNode.querySelector('#order_total_price').value);
+        }
     })
+    const totalPriceElement = document.querySelector('.shopping-cart-result');
+    if (checkBox.checked) {
+        totalPriceElement.innerText = totalPrice.toLocaleString();
+    } else {
+        totalPriceElement.innerText = 0;
+    }
 }

--- a/src/main/resources/templates/cart/index.html
+++ b/src/main/resources/templates/cart/index.html
@@ -25,7 +25,7 @@
                             <tr class="table_head">
                                 <th class="column-0">
                                     <input class="form-check-input" type="checkbox" value="" id="checkAll"
-                                           onchange="checkAll(this)" checked>
+                                           onchange="checkAll(this)">
                                 </th>
                                 <th class="column-1">이미지</th>
                                 <th class="column-2">상품명</th>
@@ -46,7 +46,9 @@
                                     <input id="order_id" name="id" th:value="${item.id}" hidden>
                                     <input id="order_quantity" name="quantity" th:value="${item.quantity}" hidden>
                                     <input id="order_name" name="name" th:value="${item.name}" hidden>
-                                    <input class="form-check-input" type="checkbox" value="" id="checkBox" checked>
+                                    <input id="order_total_price" name="price"
+                                           th:value="${item.salePrice} * ${item.quantity}" hidden>
+                                    <input class="form-check-input" type="checkbox" value="" id="checkBox">
                                 </td>
                                 <td class="column-1">
                                     <div style="position: relative; width: 110px; height: 160px; justify-content: center; align-items: center">


### PR DESCRIPTION
## 📝 작업 내용

총 주문 금액을 동적으로 표시해주는 스크립트(JS) 를 작성하여 적용하고 디자인을 적용하였습니다

- [x] 총 주문금액 (체크한 항목) 스크립트 작성
- [x] 장바구니 접근시 모든 상품 체크되어 있도록 변경
- [x] 체크 해제시 총 주문금액에서 해당 금액만큼 제거
- [x] 체크시 총 주문금액에서 해당 금액만큼 추가
- [x] 체크박스 정중앙으로 배열 변경 (FIX)

### 장바구니 페이지 접근시

- 모든 상품이 체크되어 있으며, 총 금액이 나타나 있음

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84072084/acb457e5-6ccb-421f-89d2-ef472ed91c42)

### 특정 상품 체크 해제시

- 총 주문 금액에서 해당 금액 (판매가 * 수량) 만큼 뺌

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84072084/e35c1ce7-a932-43a0-a746-b397d0a2204e)

### 특정 상품 체크시

- 총 주문 금액에서 해당 금액(판매가 * 수량) 만큼 추가

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84072084/16e8c57b-7dfb-4c93-a71a-6681d3fdf869)

### 수량 변경시

- 수량 변경 시에도 해당 내용이 반영됨

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84072084/9b8ba8bf-010b-4791-8a3f-eba01cee6c27)


## 💬 아쉬운 점

수량이 변경될 시 페이지로 다시 redirect 되기 때문에, 체크박스들이 다시 모두 체크됨

하지만, 해당 상품의 수량을 변경시킬 때 상품에 대한 Redis DB의 정보를 업데이트 시켜주어야 하고, 상품에 대한 장바구니 내용도 새로 불러와야 하기 때문에 어쩔수 없다고 생각함 (trade off)
