### PR TITLE
[FIX] 장바구니 레이아웃 수정

### DIFF
--- a/src/main/resources/templates/cart/index.html
+++ b/src/main/resources/templates/cart/index.html
@@ -18,7 +18,7 @@
     <div class="container">
         <div class="row">
             <div class="m-lr-auto m-b-50">
-                <div class="m-l-25 m-r--38 m-lr-0-xl">
+                <div class="m-lr-0-xl">
                     <h2 class="ltext-101 m-t-150">Order / Payment</h2> <br>
                     <div class="wrap-table-shopping-cart">
                         <table class="table-shopping-cart" style="text-align: center;">
@@ -37,7 +37,7 @@
                             </tr>
 
                             <tr th:if="${CART_ITEMS.isEmpty()}">
-                                <td colspan="6" class="mtext-101">
+                                <td colspan="8" class="mtext-101">
                                     장바구니가 현재 비어 있습니다
                                 </td>
                             </tr>


### PR DESCRIPTION
## 📝 작업 내용

### 기존

- Order/Payment 포함하는 element의 좌우 대칭이 맞지 않음
- 장바구니 비어있을 때 나타나는 메시지 좌우 대칭이 맞지 않음

<img width="1352" alt="image" src="https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84072084/c6210fc0-69e4-4fd6-96d4-c552ce9a3689">

### 변경 후

- 위 부분 수정 완료

<img width="1359" alt="image" src="https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84072084/07ead35b-4dda-455f-9271-37e489f4c9ce">
