### PR TITLE
[REFACTOR] 주문 상세 - 배송 상태, 주문 상태

### DIFF
--- a/src/main/java/store/ckin/front/sale/dto/DeliveryStatus.java
+++ b/src/main/java/store/ckin/front/sale/dto/DeliveryStatus.java
@@ -1,13 +1,22 @@
 package store.ckin.front.sale.dto;
 
+import lombok.Getter;
+
 /**
  * 주문의 배송 상태를 나타내는 Enum.
  *
  * @author 정승조
  * @version 2024. 03. 19.
  */
+@Getter
 public enum DeliveryStatus {
-    READY,
-    IN_PROGRESS,
-    DONE
+    READY("배송 준비 중"),
+    IN_PROGRESS("배송 중"),
+    DONE("배송 완료");
+
+    private final String status;
+
+    DeliveryStatus(String status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/store/ckin/front/sale/dto/SalePaymentStatus.java
+++ b/src/main/java/store/ckin/front/sale/dto/SalePaymentStatus.java
@@ -1,11 +1,23 @@
 package store.ckin.front.sale.dto;
 
+import lombok.Getter;
+
 /**
  * 주문의 결제 상태를 나타내는 Enum.
  *
  * @author 정승조
  * @version 2024. 03. 19.
  */
+
+@Getter
 public enum SalePaymentStatus {
-    WAITING, PAID, CANCEL
+    WAITING("결제 대기 중"),
+    PAID("결제 완료"),
+    CANCEL("결제 취소");
+
+    private final String status;
+
+    SalePaymentStatus(String status) {
+        this.status = status;
+    }
 }

--- a/src/main/resources/templates/member/mypage/order-detail.html
+++ b/src/main/resources/templates/member/mypage/order-detail.html
@@ -108,7 +108,7 @@
                             </div>
 
                             <div class="stext-104 cl2 plh4 size-115 bor13 p-lr-20 m-r-10 m-tb-5 p-t-10">
-                                배송 상태 : <span th:text="*{saleDeliveryStatus}"></span>
+                                배송 상태 : <span th:text="*{saleDeliveryStatus.getStatus()}"></span>
                             </div>
                         </div>
                     </div>
@@ -117,7 +117,7 @@
             <div class="col-sm-10 col-lg-7 col-xl-5 m-lr-auto m-b-50">
 
                 <h3 class="m-t-30 m-b-30" style="color: #00235e"
-                    th:text="'주문 결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus}"> 결제 정보 </h3>
+                    th:text="'주문 결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus.getStatus()}"> 결제 정보 </h3>
 
                 <th:block th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() eq 'WAITING'}">
                     <button class="m-t-50 btn-outline-primary btn float-l"

--- a/src/main/resources/templates/member/mypage/point-history.html
+++ b/src/main/resources/templates/member/mypage/point-history.html
@@ -23,9 +23,9 @@
                 <td th:text="${pointHistory.pointHistoryReason}"></td>
                 <td th:with="point = ${pointHistory.pointHistoryPoint}">
                     <span th:if="${point < 0}" style="color: red;"
-                          th:text="${#numbers.formatInteger(point, 3, 'COMMA')} + '원'"></span>
+                          th:text="${#numbers.formatInteger(point, 1, 'COMMA')} + '원'"></span>
                     <span th:unless="${point < 0}" style="color: green;"
-                          th:text="${#numbers.formatInteger(point, 3, 'COMMA')} + '원'"></span>
+                          th:text="${#numbers.formatInteger(point, 1, 'COMMA')} + '원'"></span>
                 </td>
                 <td th:text="${#temporals.format(pointHistory.pointHistoryTime, 'yyyy-MM-dd')}"></td>
             </tr>

--- a/src/main/resources/templates/sale/guest-order-detail.html
+++ b/src/main/resources/templates/sale/guest-order-detail.html
@@ -111,7 +111,7 @@
                             </div>
 
                             <div class="stext-104 cl2 plh4 size-115 bor13 p-lr-20 m-r-10 m-tb-5 p-t-10">
-                                배송 상태 : <span th:text="*{saleDeliveryStatus}"></span>
+                                배송 상태 : <span th:text="*{saleDeliveryStatus.getStatus()}"></span>
                             </div>
                         </div>
                     </div>
@@ -120,7 +120,7 @@
             <div class="col-sm-10 col-lg-7 col-xl-5 m-lr-auto m-b-50">
 
                 <h4 class="h4 m-t-30 m-b-30" style="color: #00235e"
-                    th:text="'주문 결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus}"> 결제 정보 </h4>
+                    th:text="'주문 결제 정보 : ' + ${saleDetail.saleResponseDto.salePaymentStatus.getStatus()}"> 결제 정보 </h4>
 
                 <th:block th:if="${saleDetail.saleResponseDto.salePaymentStatus.name() eq 'WAITING'}">
                     <button class="m-t-50 btn-outline-primary btn float-l"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[[QA] 마이페이지 주문 상세 뷰](https://github.com/nhnacademy-be4-ckin/ckin-management/issues/60)

## 📝 작업 내용

배송 상태와 결제 상태가 Enum 값 그대로 표시되어 영어로 표현되었던 것을 값을 설정하여 한글로 보여지게 변경하였습니다.

![image](https://github.com/nhnacademy-be4-ckin/ckin-front/assets/84575041/186ed541-160c-4788-a5df-dafe8aa14fcd)



