### PR TITLE
[FEAT] 장바구니 회원별 저장 및 불러오기 로직 추가

### DIFF
--- a/src/main/java/store/ckin/front/auth/CustomLogoutHandler.java
+++ b/src/main/java/store/ckin/front/auth/CustomLogoutHandler.java
@@ -27,6 +27,8 @@ public class CustomLogoutHandler implements LogoutHandler {
     public void logout(HttpServletRequest request,
                        HttpServletResponse response,
                        Authentication authentication) {
+        // 유저의 장바구니 아이디를 삭제
+        CookieUtil.resetCookie(request, response, "CART_ID");
         deleteDataIfCookieExists(request, response, JwtUtil.HEADER_ACCESS_TOKEN);
         deleteDataIfCookieExists(request, response, JwtUtil.HEADER_REFRESH_TOKEN);
     }

--- a/src/main/java/store/ckin/front/cart/adapter/CartAdapter.java
+++ b/src/main/java/store/ckin/front/cart/adapter/CartAdapter.java
@@ -1,5 +1,8 @@
 package store.ckin.front.cart.adapter;
 
+import store.ckin.front.cart.dto.request.CartCreateRequestDto;
+import store.ckin.front.cart.dto.response.CartIdResponseDto;
+
 /**
  * description
  *
@@ -7,4 +10,7 @@ package store.ckin.front.cart.adapter;
  * @version 2024. 02. 27
  */
 public interface CartAdapter {
+    void insertCart(CartCreateRequestDto cartCreateRequestDto);
+
+    CartIdResponseDto selectCartIdByMemberId(Long memberId);
 }

--- a/src/main/java/store/ckin/front/cart/adapter/impl/CartAdapterImpl.java
+++ b/src/main/java/store/ckin/front/cart/adapter/impl/CartAdapterImpl.java
@@ -1,6 +1,23 @@
 package store.ckin.front.cart.adapter.impl;
 
+import static store.ckin.front.util.AdapterHeaderUtil.getHttpHeaders;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 import store.ckin.front.cart.adapter.CartAdapter;
+import store.ckin.front.cart.dto.request.CartCreateRequestDto;
+import store.ckin.front.cart.dto.response.CartIdResponseDto;
+import store.ckin.front.cart.exception.CartNotFoundException;
+import store.ckin.front.config.properties.GatewayProperties;
 
 /**
  * description
@@ -8,5 +25,47 @@ import store.ckin.front.cart.adapter.CartAdapter;
  * @author 김준현
  * @version 2024. 02. 27
  */
+@Component
+@RequiredArgsConstructor
 public class CartAdapterImpl implements CartAdapter {
+    private final RestTemplate restTemplate;
+    private final GatewayProperties gatewayProperties;
+    private static final String CART_URL = "/api/cart";
+
+    @Override
+    public void insertCart(CartCreateRequestDto cartCreateRequestDto) {
+        HttpEntity<CartCreateRequestDto> requestEntity = new HttpEntity<>(cartCreateRequestDto, getHttpHeaders());
+
+        restTemplate.exchange(gatewayProperties.getGatewayUri() + CART_URL,
+                HttpMethod.POST,
+                requestEntity,
+                new ParameterizedTypeReference<>() {
+                });
+    }
+
+    @Override
+    public CartIdResponseDto selectCartIdByMemberId(Long memberId) {
+        HttpEntity<Void> requestEntity = new HttpEntity<>(getHttpHeaders());
+        URI uri = UriComponentsBuilder
+                .fromUriString(gatewayProperties.getGatewayUri())
+                .path(CART_URL)
+                .queryParam("memberId", memberId)
+                .encode().build().toUri();
+
+        HttpStatus status;
+        try {
+            ResponseEntity<CartIdResponseDto> exchange = restTemplate.exchange(uri,
+                    HttpMethod.GET,
+                    requestEntity,
+                    new ParameterizedTypeReference<>() {
+                    });
+            return exchange.getBody();
+        } catch (HttpClientErrorException e) {
+            status = e.getStatusCode();
+            if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new CartNotFoundException();
+            }
+        }
+        throw new HttpClientErrorException(status);
+    }
 }

--- a/src/main/java/store/ckin/front/cart/dto/request/CartCreateRequestDto.java
+++ b/src/main/java/store/ckin/front/cart/dto/request/CartCreateRequestDto.java
@@ -1,0 +1,17 @@
+package store.ckin.front.cart.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * description:
+ *
+ * @author : dduneon
+ * @version : 2024. 03. 26
+ */
+@AllArgsConstructor
+@Getter
+public class CartCreateRequestDto {
+    private Long memberId;
+    private String cartId;
+}

--- a/src/main/java/store/ckin/front/cart/dto/response/CartIdResponseDto.java
+++ b/src/main/java/store/ckin/front/cart/dto/response/CartIdResponseDto.java
@@ -1,0 +1,16 @@
+package store.ckin.front.cart.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * description:
+ *
+ * @author : dduneon
+ * @version : 2024. 03. 26
+ */
+@NoArgsConstructor
+@Getter
+public class CartIdResponseDto {
+    private String cartId;
+}

--- a/src/main/java/store/ckin/front/cart/exception/CartNotFoundException.java
+++ b/src/main/java/store/ckin/front/cart/exception/CartNotFoundException.java
@@ -1,0 +1,10 @@
+package store.ckin.front.cart.exception;
+
+/**
+ * description:
+ *
+ * @author : dduneon
+ * @version : 2024. 03. 26
+ */
+public class CartNotFoundException extends RuntimeException {
+}

--- a/src/main/java/store/ckin/front/cart/service/CartService.java
+++ b/src/main/java/store/ckin/front/cart/service/CartService.java
@@ -2,10 +2,12 @@ package store.ckin.front.cart.service;
 
 import java.util.List;
 import store.ckin.front.cart.dto.domain.CartItem;
+import store.ckin.front.cart.dto.request.CartCreateRequestDto;
 import store.ckin.front.cart.dto.request.CartItemCreateRequestDto;
 import store.ckin.front.cart.dto.request.CartItemDeleteRequestDto;
 import store.ckin.front.cart.dto.request.CartItemOrderDto;
 import store.ckin.front.cart.dto.request.CartItemUpdateRequestDto;
+import store.ckin.front.cart.dto.response.CartIdResponseDto;
 
 /**
  * 장바구니 임시 저장을 담당하는 서비스 클래스
@@ -77,4 +79,8 @@ public interface CartService {
      * @param key 현재 유저의 UUID
      */
     void deleteCartItemAll(String key);
+
+    void createMemberCart(CartCreateRequestDto cartCreateRequestDto);
+
+    CartIdResponseDto readMemberCartId(Long memberId);
 }

--- a/src/main/java/store/ckin/front/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/store/ckin/front/cart/service/impl/CartServiceImpl.java
@@ -35,7 +35,7 @@ import store.ckin.front.cart.service.CartService;
 public class CartServiceImpl implements CartService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final CartAdapter cartAdapter;
-    private static final Duration EXPIRE_CART_ITEMS = Duration.ofDays(2);
+    private static final Duration EXPIRE_CART_ITEMS = Duration.ofDays(30);
     private static final String CART_HASH_KEY = "user_cart";
     private static final String ORDER_HASH_KEY = "user_order";
 
@@ -69,6 +69,7 @@ public class CartServiceImpl implements CartService {
         }
         currentUserCart.add(CartItem.toCartItem(item));
         redisTemplate.opsForHash().put(key, CART_HASH_KEY, currentUserCart);
+        redisTemplate.expire(key, EXPIRE_CART_ITEMS);
     }
 
     /**
@@ -119,6 +120,7 @@ public class CartServiceImpl implements CartService {
         updatedItem.updateQuantity(cartItemUpdateRequestDto.getQuantity());
 
         redisTemplate.opsForHash().put(key, CART_HASH_KEY, currentUserCart);
+        redisTemplate.expire(key, EXPIRE_CART_ITEMS);
     }
 
     /**
@@ -136,6 +138,7 @@ public class CartServiceImpl implements CartService {
         }
 
         redisTemplate.opsForHash().put(key, CART_HASH_KEY, currentUserCart);
+        redisTemplate.expire(key, EXPIRE_CART_ITEMS);
     }
 
     /**
@@ -180,6 +183,7 @@ public class CartServiceImpl implements CartService {
 
         currentUserCart.removeAll(deletedCartItem);
         hashOperations.put(key, CART_HASH_KEY, currentUserCart);
+        redisTemplate.expire(key, EXPIRE_CART_ITEMS);
     }
 
     @Override

--- a/src/main/java/store/ckin/front/cart/service/impl/CartServiceImpl.java
+++ b/src/main/java/store/ckin/front/cart/service/impl/CartServiceImpl.java
@@ -11,12 +11,16 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import store.ckin.front.cart.adapter.CartAdapter;
 import store.ckin.front.cart.dto.domain.CartItem;
+import store.ckin.front.cart.dto.request.CartCreateRequestDto;
 import store.ckin.front.cart.dto.request.CartItemCreateRequestDto;
 import store.ckin.front.cart.dto.request.CartItemDeleteRequestDto;
 import store.ckin.front.cart.dto.request.CartItemOrderDto;
 import store.ckin.front.cart.dto.request.CartItemUpdateRequestDto;
+import store.ckin.front.cart.dto.response.CartIdResponseDto;
 import store.ckin.front.cart.exception.CartItemNotFoundException;
+import store.ckin.front.cart.exception.CartNotFoundException;
 import store.ckin.front.cart.exception.ItemAlreadyExistException;
 import store.ckin.front.cart.exception.OrderFailedException;
 import store.ckin.front.cart.service.CartService;
@@ -30,12 +34,15 @@ import store.ckin.front.cart.service.CartService;
 @Service
 public class CartServiceImpl implements CartService {
     private final RedisTemplate<String, Object> redisTemplate;
+    private final CartAdapter cartAdapter;
     private static final Duration EXPIRE_CART_ITEMS = Duration.ofDays(2);
     private static final String CART_HASH_KEY = "user_cart";
     private static final String ORDER_HASH_KEY = "user_order";
 
-    public CartServiceImpl(@Qualifier("redisTemplate") RedisTemplate<String, Object> redisTemplate) {
+    public CartServiceImpl(@Qualifier("redisTemplate") RedisTemplate<String, Object> redisTemplate,
+                           CartAdapter cartAdapter) {
         this.redisTemplate = redisTemplate;
+        this.cartAdapter = cartAdapter;
     }
 
     /**
@@ -173,6 +180,20 @@ public class CartServiceImpl implements CartService {
 
         currentUserCart.removeAll(deletedCartItem);
         hashOperations.put(key, CART_HASH_KEY, currentUserCart);
+    }
+
+    @Override
+    public void createMemberCart(CartCreateRequestDto cartCreateRequestDto) {
+        cartAdapter.insertCart(cartCreateRequestDto);
+    }
+
+    @Override
+    public CartIdResponseDto readMemberCartId(Long memberId) {
+        try {
+            return cartAdapter.selectCartIdByMemberId(memberId);
+        } catch (CartNotFoundException e) {
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/store/ckin/front/member/filter/CustomLoginFilter.java
+++ b/src/main/java/store/ckin/front/member/filter/CustomLoginFilter.java
@@ -16,6 +16,7 @@ import store.ckin.front.exception.ServerErrorException;
 import store.ckin.front.token.domain.TokenRequestDto;
 import store.ckin.front.token.domain.TokenResponseDto;
 import store.ckin.front.token.service.TokenService;
+import store.ckin.front.util.CookieUtil;
 import store.ckin.front.util.JwtUtil;
 
 /**
@@ -60,6 +61,8 @@ public class CustomLoginFilter extends UsernamePasswordAuthenticationFilter {
             TokenResponseDto tokenResponseDto = tokenService.getToken(new TokenRequestDto(id, authority));
             JwtUtil.addTokenCookie(response, tokenResponseDto);
 
+            // 로그인 시 기존 장바구니 아이디 쿠키 삭제
+            CookieUtil.resetCookie(request, response, "CART_ID");
             response.sendRedirect("/");
         } catch (ServerErrorException ex) {
             log.error("CustomLoginFilter.successfulAuthentication() : Internal Server Error");


### PR DESCRIPTION
## 📝 작업 내용

### DB

- 회원별 장바구니 추가
  - DB(MySQL) 에 member Id별 cart Id(1 to 1) 지정 및 저장

### Logic

- Redis에서 회원 장바구니 연산시 expire 연장 로직 추가
- 로그인 시 회원의 장바구니 아이디가 DB에 존재하지 않으면 생성 후 저장, 있다면 불러와서 저장
- 로그아웃 시 장바구니 쿠키 삭제

### Description

- 회원의 장바구니 ID Cookie 는 access Token, refresh Token 의 expire과 같음
  - 토큰 만료시 장바구니도 삭제되어 접근 불가능 

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
